### PR TITLE
Changing flask-security to flask-security-too

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,7 +41,7 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
         cache: 'pip'
@@ -53,7 +53,7 @@ jobs:
     - name: Set up Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v3
       with:
-        python-version: ${{ matrix.node-version }}
+        node-version: ${{ matrix.node-version }}
 
     - name: Install newman
       run: npm install -g newman
@@ -64,7 +64,7 @@ jobs:
 
     - name: Run the application and Postman's tests
       run: |
-        gunicorn -b localhost:5000 -w 4 "arcsi:create_app('../config_ci.py')" --daemon
+        gunicorn -b localhost:5000 -w 4 "arcsi:create_app('../config_ci.py')" --daemon --log-file aguni.log --log-level debug
         cd test/postman/ && newman run test.postman_collection.json -e test.postman_environment.json -k
       env:
         FLASK_ENV: development
@@ -79,3 +79,10 @@ jobs:
         POSTGRES_USER: postgres
         POSTGRES_PASSWORD: p0stgr3s
         POSTGRES_DB: arcsi
+        CI: true
+
+    - name: Upload logs
+      uses: actions/upload-artifact@v3
+      if: failure()
+      with:
+        path: aguni.log

--- a/arcsi/api/item.py
+++ b/arcsi/api/item.py
@@ -216,10 +216,13 @@ def add_item():
                 # we require both image and audio if broadcast (Azuracast) is set
                 if not (image_file_name and new_item.play_file_name):
                     no_error = False
+                    app.logger.debug("ERROR: Both image and audio input are required if broadcast (Azuracast) is set")
             # this branch is typically used for pre-uploading live episodes (no audio)
             else: 
                 if not image_file_name:
                     no_error = False
+                    app.logger.debug("ERROR: You need to add at least an image")
+                    
 
         # archive files if asked
         if new_item.archive_lahmastore:
@@ -232,6 +235,8 @@ def add_item():
                     )
                     if not new_item.image_url:
                         no_error = False
+                        app.logger.debug("ERROR: Image could not be uploaded to storage")
+
                 if new_item.play_file_name:
                     new_item.archive_lahmastore_canonical_url = archive(
                         archive_base=new_item.shows[0].archive_lahmastore_base_url,
@@ -244,6 +249,8 @@ def add_item():
                         new_item.archived = True
                     else:  # Upload didn't succeed
                         no_error = False
+                        app.logger.debug("ERROR: Audio could not be uploaded to storage")
+
 
         # broadcast episode if asked
         if new_item.broadcast and no_error:
@@ -261,6 +268,8 @@ def add_item():
                 )
                 if not new_item.airing:
                     no_error = False
+                    app.logger.debug("ERROR: Item could not be uploaded to Azuracast")
+
 
             # TODO some mp3 error
             # TODO Maybe I used vanilla mp3 not from azuracast

--- a/arcsi/api/item.py
+++ b/arcsi/api/item.py
@@ -1,6 +1,7 @@
 from datetime import datetime, timedelta
 
 from flask import jsonify, make_response, request, redirect
+from flask import current_app as app
 from flask_security import auth_token_required, roles_required
 from marshmallow import fields, post_load, Schema
 from sqlalchemy import func

--- a/arcsi/api/show.py
+++ b/arcsi/api/show.py
@@ -297,11 +297,15 @@ def edit_show(id):
                     archive_file_name=(show.name, "cover"),
                 )
                 if cover_image_name:
+                    app.logger.debug("STATUS: Cover image name: {}".format(cover_image_name))
                     show.cover_image_url = archive(
                         archive_base=show.archive_lahmastore_base_url,
                         archive_idx=0,
                         archive_file_name=cover_image_name,
                     )
+                    app.logger.debug("STATUS: Cover image url: {}".format(show.cover_image_url))
+                else:
+                    app.logger.debug("ERROR: Error while uploading cover image.")
 
         db.session.commit()
         return make_response(

--- a/arcsi/api/show.py
+++ b/arcsi/api/show.py
@@ -2,6 +2,7 @@ import json
 
 from datetime import datetime, timedelta
 from flask import jsonify, make_response, request
+from flask import current_app as app
 from flask_security import auth_token_required, roles_required
 from marshmallow import fields, post_load, Schema
 from sqlalchemy import func

--- a/arcsi/api/utils.py
+++ b/arcsi/api/utils.py
@@ -122,16 +122,21 @@ def broadcast_audio(
 
 def save_file(archive_base, archive_idx, archive_file, archive_file_name):
     formed_file_name = form_filename(archive_file, archive_file_name)
+    app.logger.debug("STATUS/SAVE FILE: formed_file_name: {}".format(formed_file_name))
     if not allowed_file(formed_file_name):
+        app.logger.debug("STATUS/SAVE FILE: Not allowed file. See ALLOWED_EXTENSIONS")
         return None
     else:
         if formed_file_name == "":
             return None
+            app.logger.debug("STATUS/SAVE FILE: File name could not be computed")
         else:
             archive_file_path = media_path(
                 archive_base, str(archive_idx), formed_file_name
             )
+            app.logger.debug("STATUS/SAVE FILE: archive_file_path: {}".format(archive_file_path))
             archive_file.save(archive_file_path)
+            app.logger.debug("STATUS/SAVE FILE: archive_file: {}".format(archive_file))
             return formed_file_name
 
 

--- a/arcsi/model/user.py
+++ b/arcsi/model/user.py
@@ -14,7 +14,7 @@ class User(db.Model, UserMixin):
     butt_user = db.Column(db.String())
     butt_pw = db.Column(db.String(128))
     roles = db.relationship(
-        "Role", secondary=roles_users, backref=db.backref("users")
+        "Role", secondary=roles_users, backref=db.backref("users"), lazy="dynamic"
     )
     shows = db.relationship(
         "Show",

--- a/arcsi/model/user.py
+++ b/arcsi/model/user.py
@@ -14,7 +14,7 @@ class User(db.Model, UserMixin):
     butt_user = db.Column(db.String())
     butt_pw = db.Column(db.String(128))
     roles = db.relationship(
-        "Role", secondary=roles_users, backref=db.backref("users"), lazy="dynamic"
+        "Role", secondary=roles_users, backref=db.backref("users")
     )
     shows = db.relationship(
         "Show",

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,7 @@ Flask-Mail==0.9.1
 flask-marshmallow==0.12.0
 Flask-Migrate==2.5.2
 Flask-Principal==0.4.0
-Flask-Security-Too==3.1.0
+Flask-Security-Too==3.1.0rc1
 Flask-SQLAlchemy==2.4.2
 Flask-WTF==0.14.3
 flowjs==0.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,7 @@ Flask-Mail==0.9.1
 flask-marshmallow==0.12.0
 Flask-Migrate==2.5.2
 Flask-Principal==0.4.0
-Flask-Security-Too==3.0.2
+Flask-Security-Too==3.2.0
 Flask-SQLAlchemy==2.4.2
 Flask-WTF==0.14.3
 flowjs==0.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,7 @@ Flask-Mail==0.9.1
 flask-marshmallow==0.12.0
 Flask-Migrate==2.5.2
 Flask-Principal==0.4.0
-Flask-Security-Too==3.2.0
+Flask-Security-Too==3.0.2
 Flask-SQLAlchemy==2.4.2
 Flask-WTF==0.14.3
 flowjs==0.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,7 @@ Flask-Mail==0.9.1
 flask-marshmallow==0.12.0
 Flask-Migrate==2.5.2
 Flask-Principal==0.4.0
-Flask-Security==3.0.0
+Flask-Security-Too==3.0.2
 Flask-SQLAlchemy==2.4.2
 Flask-WTF==0.14.3
 flowjs==0.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,7 @@ Flask-Mail==0.9.1
 flask-marshmallow==0.12.0
 Flask-Migrate==2.5.2
 Flask-Principal==0.4.0
-Flask-Security-Too==3.1.0rc1
+Flask-Security-Too==3.0.2
 Flask-SQLAlchemy==2.4.2
 Flask-WTF==0.14.3
 flowjs==0.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,7 @@ Flask-Mail==0.9.1
 flask-marshmallow==0.12.0
 Flask-Migrate==2.5.2
 Flask-Principal==0.4.0
-Flask-Security-Too==3.0.2
+Flask-Security-Too==3.1.0
 Flask-SQLAlchemy==2.4.2
 Flask-WTF==0.14.3
 flowjs==0.1.1

--- a/test/postman/test.postman_collection.json
+++ b/test/postman/test.postman_collection.json
@@ -1,12 +1,12 @@
 {
 	"info": {
-		"_postman_id": "f8aeca05-6c90-4215-aa89-4977d913683a",
+		"_postman_id": "c6974ba5-bf1f-4b09-a1c9-365cbd75850e",
 		"name": "CI test",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
 	"item": [
 		{
-			"name": "get_api_token()",
+			"name": "Get API Token (get_api_token())",
 			"event": [
 				{
 					"listen": "test",
@@ -63,7 +63,7 @@
 			"response": []
 		},
 		{
-			"name": "list_shows()",
+			"name": "Get Shows (0, list_shows())",
 			"event": [
 				{
 					"listen": "test",
@@ -163,7 +163,7 @@
 			"response": []
 		},
 		{
-			"name": "add_show()",
+			"name": "Add Show (add_show())",
 			"event": [
 				{
 					"listen": "test",
@@ -330,7 +330,7 @@
 			"response": []
 		},
 		{
-			"name": "list_shows()",
+			"name": "Get Shows (1, list_shows())",
 			"event": [
 				{
 					"listen": "test",
@@ -430,7 +430,7 @@
 			"response": []
 		},
 		{
-			"name": "view_show(id)",
+			"name": "Get Show (view_show(id))",
 			"event": [
 				{
 					"listen": "test",
@@ -529,7 +529,7 @@
 			"response": []
 		},
 		{
-			"name": "list_items()",
+			"name": "Get Items (0, list_items())",
 			"event": [
 				{
 					"listen": "test",
@@ -619,7 +619,7 @@
 			"response": []
 		},
 		{
-			"name": "add_item() 1 new live",
+			"name": "Add Item (1 live, add_item())",
 			"event": [
 				{
 					"listen": "test",
@@ -633,8 +633,8 @@
 							"    pm.response.to.be.header(\"Content-Type\", \"application/json\")\r",
 							"});\r",
 							"\r",
-							"pm.test(\"API responds within 10 sec (\" + pm.response.responseTime + \" msec)\", () => {\r",
-							"    const expectedTimeInMilliseconds = 12500;\r",
+							"pm.test(\"API responds within 15 sec (\" + pm.response.responseTime + \" msec)\", () => {\r",
+							"    const expectedTimeInMilliseconds = 15000;\r",
 							"    pm.expect(pm.response.responseTime).to.be.lessThan(\r",
 							"        expectedTimeInMilliseconds + 1,\r",
 							"        `Response came in ${pm.response.responseTime} ms`);\r",
@@ -775,7 +775,7 @@
 			"response": []
 		},
 		{
-			"name": "list_items()",
+			"name": "Get Items (1, list_items())",
 			"event": [
 				{
 					"listen": "test",
@@ -865,7 +865,7 @@
 			"response": []
 		},
 		{
-			"name": "edit_item(id) 1 live -> broadcast",
+			"name": "Edit Item (1 live -> broadcast, edit_item(id))",
 			"event": [
 				{
 					"listen": "test",
@@ -879,8 +879,8 @@
 							"    pm.response.to.be.header(\"Content-Type\", \"application/json\")\r",
 							"});\r",
 							"\r",
-							"pm.test(\"API responds within 10 sec (\" + pm.response.responseTime + \" msec)\", () => {\r",
-							"    const expectedTimeInMilliseconds = 12500;\r",
+							"pm.test(\"API responds within 15 sec (\" + pm.response.responseTime + \" msec)\", () => {\r",
+							"    const expectedTimeInMilliseconds = 15000;\r",
 							"    pm.expect(pm.response.responseTime).to.be.lessThan(\r",
 							"        expectedTimeInMilliseconds + 1,\r",
 							"        `Response came in ${pm.response.responseTime} ms`);\r",
@@ -1034,7 +1034,7 @@
 			"response": []
 		},
 		{
-			"name": "add_item() 2 new broadcast",
+			"name": "Add Item (2 broadcast, add_item())",
 			"event": [
 				{
 					"listen": "test",
@@ -1048,8 +1048,8 @@
 							"    pm.response.to.be.header(\"Content-Type\", \"application/json\")\r",
 							"});\r",
 							"\r",
-							"pm.test(\"API responds within 10 sec (\" + pm.response.responseTime + \" msec)\", () => {\r",
-							"    const expectedTimeInMilliseconds = 12500;\r",
+							"pm.test(\"API responds within 15 sec (\" + pm.response.responseTime + \" msec)\", () => {\r",
+							"    const expectedTimeInMilliseconds = 15000;\r",
 							"    pm.expect(pm.response.responseTime).to.be.lessThan(\r",
 							"        expectedTimeInMilliseconds + 1,\r",
 							"        `Response came in ${pm.response.responseTime} ms`);\r",
@@ -1189,7 +1189,7 @@
 			"response": []
 		},
 		{
-			"name": "list_items()",
+			"name": "Get Items (2, list_items())",
 			"event": [
 				{
 					"listen": "test",
@@ -1279,7 +1279,7 @@
 			"response": []
 		},
 		{
-			"name": "add_item() 2 broadcast override",
+			"name": "Add Item (2 broadcast override, add_item())",
 			"event": [
 				{
 					"listen": "test",
@@ -1293,8 +1293,8 @@
 							"    pm.response.to.be.header(\"Content-Type\", \"application/json\")\r",
 							"});\r",
 							"\r",
-							"pm.test(\"API responds within 10 sec (\" + pm.response.responseTime + \" msec)\", () => {\r",
-							"    const expectedTimeInMilliseconds = 12500;\r",
+							"pm.test(\"API responds within 15 sec (\" + pm.response.responseTime + \" msec)\", () => {\r",
+							"    const expectedTimeInMilliseconds = 15000;\r",
 							"    pm.expect(pm.response.responseTime).to.be.lessThan(\r",
 							"        expectedTimeInMilliseconds + 1,\r",
 							"        `Response came in ${pm.response.responseTime} ms`);\r",
@@ -1434,7 +1434,7 @@
 			"response": []
 		},
 		{
-			"name": "list_items()",
+			"name": "Get Items (3, list_items())",
 			"event": [
 				{
 					"listen": "test",
@@ -1524,7 +1524,7 @@
 			"response": []
 		},
 		{
-			"name": "add_item() 3 new live",
+			"name": "Add Item (3 live, add_item())",
 			"event": [
 				{
 					"listen": "test",
@@ -1538,8 +1538,8 @@
 							"    pm.response.to.be.header(\"Content-Type\", \"application/json\")\r",
 							"});\r",
 							"\r",
-							"pm.test(\"API responds within 10 sec (\" + pm.response.responseTime + \" msec)\", () => {\r",
-							"    const expectedTimeInMilliseconds = 12500;\r",
+							"pm.test(\"API responds within 15 sec (\" + pm.response.responseTime + \" msec)\", () => {\r",
+							"    const expectedTimeInMilliseconds = 15000;\r",
 							"    pm.expect(pm.response.responseTime).to.be.lessThan(\r",
 							"        expectedTimeInMilliseconds + 1,\r",
 							"        `Response came in ${pm.response.responseTime} ms`);\r",
@@ -1680,7 +1680,7 @@
 			"response": []
 		},
 		{
-			"name": "list_items()",
+			"name": "Get Items (4, list_items())",
 			"event": [
 				{
 					"listen": "test",
@@ -1770,7 +1770,7 @@
 			"response": []
 		},
 		{
-			"name": "edit_item(id) 3 live -> broadcast",
+			"name": "Edit Item (3 live -> broadcast, edit_item(id))",
 			"event": [
 				{
 					"listen": "test",
@@ -1784,8 +1784,8 @@
 							"    pm.response.to.be.header(\"Content-Type\", \"application/json\")\r",
 							"});\r",
 							"\r",
-							"pm.test(\"API responds within 10 sec (\" + pm.response.responseTime + \" msec)\", () => {\r",
-							"    const expectedTimeInMilliseconds = 12500;\r",
+							"pm.test(\"API responds within 15 sec (\" + pm.response.responseTime + \" msec)\", () => {\r",
+							"    const expectedTimeInMilliseconds = 15000;\r",
 							"    pm.expect(pm.response.responseTime).to.be.lessThan(\r",
 							"        expectedTimeInMilliseconds + 1,\r",
 							"        `Response came in ${pm.response.responseTime} ms`);\r",
@@ -1939,7 +1939,7 @@
 			"response": []
 		},
 		{
-			"name": "edit_item(id) 3 broadcast edit",
+			"name": "Edit Item (3 broadcast, edit_item(id))",
 			"event": [
 				{
 					"listen": "test",
@@ -1953,8 +1953,8 @@
 							"    pm.response.to.be.header(\"Content-Type\", \"application/json\")\r",
 							"});\r",
 							"\r",
-							"pm.test(\"API responds within 10 sec (\" + pm.response.responseTime + \" msec)\", () => {\r",
-							"    const expectedTimeInMilliseconds = 12500;\r",
+							"pm.test(\"API responds within 15 sec (\" + pm.response.responseTime + \" msec)\", () => {\r",
+							"    const expectedTimeInMilliseconds = 15000;\r",
 							"    pm.expect(pm.response.responseTime).to.be.lessThan(\r",
 							"        expectedTimeInMilliseconds + 1,\r",
 							"        `Response came in ${pm.response.responseTime} ms`);\r",
@@ -2108,7 +2108,7 @@
 			"response": []
 		},
 		{
-			"name": "list_items()",
+			"name": "Get Items (4, list_items())",
 			"event": [
 				{
 					"listen": "test",
@@ -2198,7 +2198,7 @@
 			"response": []
 		},
 		{
-			"name": "view_item(id)",
+			"name": "View Item (4, view_item(id))",
 			"event": [
 				{
 					"listen": "test",
@@ -2287,7 +2287,7 @@
 			"response": []
 		},
 		{
-			"name": "list_items_latest()",
+			"name": "Get Latest Items (list_items_latest())",
 			"event": [
 				{
 					"listen": "test",
@@ -2366,7 +2366,7 @@
 			"response": []
 		},
 		{
-			"name": "search_item()",
+			"name": "Search Item (search_item())",
 			"event": [
 				{
 					"listen": "test",
@@ -2467,7 +2467,7 @@
 			"response": []
 		},
 		{
-			"name": "view_episode_archive(show_slug, item_slug)",
+			"name": "View Item with Slug (view_episode_archive(show_slug, item_slug))",
 			"event": [
 				{
 					"listen": "test",
@@ -2545,7 +2545,7 @@
 			"response": []
 		},
 		{
-			"name": "list_shows_page()",
+			"name": "Get Shows Paginated (list_shows_page())",
 			"event": [
 				{
 					"listen": "test",
@@ -2604,7 +2604,7 @@
 			"response": []
 		},
 		{
-			"name": "list_shows_without_items()",
+			"name": "Get Shows without Items (list_shows_without_items())",
 			"event": [
 				{
 					"listen": "test",
@@ -2678,7 +2678,7 @@
 			"response": []
 		},
 		{
-			"name": "search_show()",
+			"name": "Search Show (search_show())",
 			"event": [
 				{
 					"listen": "test",
@@ -2766,7 +2766,7 @@
 			"response": []
 		},
 		{
-			"name": "list_shows_for_schedule()",
+			"name": "Get Shows for Schedule (list_shows_for_schedule())",
 			"event": [
 				{
 					"listen": "test",
@@ -2840,7 +2840,7 @@
 			"response": []
 		},
 		{
-			"name": "list_shows_for_schedule_by()",
+			"name": "Get Shows for Schedule by Day (list_shows_for_schedule_by())",
 			"event": [
 				{
 					"listen": "test",
@@ -2963,7 +2963,7 @@
 			"response": []
 		},
 		{
-			"name": "view_show_page(show_slug)",
+			"name": "Get Show for Show Subpage (view_show_page(show_slug))",
 			"event": [
 				{
 					"listen": "test",


### PR DESCRIPTION
The currently used [flask-security](https://flask-security.readthedocs.io/en/3.0.0/) package is no longer supported (latest change is 2,5 years old), [flask-security-too](https://flask-security-too.readthedocs.io/en/stable/) is the maintained up-to-date version of it.

Previously we talked about @gammaw that introducing the authentication made the frontend page is a bit slower.
This new security package offers some performance boost with version [3.1.0](https://github.com/Flask-Middleware/flask-security/blob/master/CHANGES.rst#version-310) and [3.2.0](https://github.com/Flask-Middleware/flask-security/blob/master/CHANGES.rst#version-320), for these uplifts we need a [modification](https://github.com/lahmacunradio/arcsi/pull/157/files/db80fc450235b0191d312f721a6aa68717fdfd73#diff-b221de923024f3e630e3d372fae43d57a72164cbe70f71b0dd9df23b36606983) which looks like a DB change [but it's not that](https://github.com/lahmacunradio/arcsi/pull/157/files/db80fc450235b0191d312f721a6aa68717fdfd73#diff-4d7c51b1efe9043e44439a949dfd92e5827321b34082903477fd04876edb7552).

We agreed that we should do some performance measurement before these upgrades:

- @gammaw suggested to do a profiling on the front end page to see exactly how much time each transaction takes
- I recommended to extend our CI with a robustness/benchmark test which can simulate a big load of incoming GET requests and measure the time it takes.

Because of the previously mentioned reasons I moved back to version 3.0.2, since this PR will be just about introducing the new flask-security package and probably the CI upgrade.