### PR TITLE
New endpoint for analytics

### DIFF
--- a/arcsi/api/__init__.py
+++ b/arcsi/api/__init__.py
@@ -6,6 +6,7 @@ from .item import *
 from .role import *
 from .show import *
 from .user import *
+from .data import *
 
 # TODO add routing here eg
 # arcsi.route("/archive", methods=["GET"])(<method_name>)

--- a/arcsi/api/data.py
+++ b/arcsi/api/data.py
@@ -22,7 +22,7 @@ def uploaded_episodes_in_last_x_days():
     episodes_count = Item.query.filter(
         given_date - timedelta(days=last_days) <= Item.play_date
         ).filter(Item.play_date <= datetime.today()
-        ).filter(Item.archived == True).count()
+        ).count()
     ret = {"uploaded_episodes_in_last_%d_days" % (last_days): episodes_count}
     return make_response(jsonify(ret), 200, headers)
 
@@ -40,6 +40,6 @@ def uploaded_episodes_in_last_x_weeks():
     episodes_count = Item.query.filter(
         given_date - timedelta(weeks=last_weeks) <= Item.play_date
         ).filter(Item.play_date <= datetime.today()
-        ).filter(Item.archived == True).count()
+        ).count()
     ret = {"uploaded_episodes_in_last_%d_weeks" % (last_weeks): episodes_count}
     return make_response(jsonify(ret), 200, headers)

--- a/arcsi/api/data.py
+++ b/arcsi/api/data.py
@@ -1,51 +1,41 @@
-from datetime import date, timedelta
+from datetime import datetime, timedelta
 
 from flask import jsonify, make_response, request
-from flask_security import auth_token_required
+from flask_security import roles_required
 
 from . import arcsi
 from arcsi.model.item import Item
 
 headers = {"Content-Type": "application/json"}
 
-@arcsi.route("/data/episodes_uploaded_daily", methods=["GET"])
-@auth_token_required
-def get_uploaded_episodes_in_last_x_days():
-    year = request.args.get('year', date.today().year(), type=int)
-    if (year > date.today().year()):
+@arcsi.route("/data/episodes_uploaded_daily", methods=["POST"])
+@roles_required("guest")
+def uploaded_episodes_in_last_x_days():
+    date_metadata = request.form.to_dict()
+    from_date = date_metadata['from_date']
+    given_date = datetime.strptime(from_date, '%Y-%m-%d')
+    if (given_date > datetime.today()):
         return make_response("Back to the future?", 418, headers)
-    month = request.args.get('month', date.today().month(), type=int)
-    if (year == date.today().year() and month > date.today().month()):
-        return make_response("Back to the future?", 418, headers)
-    day = request.args.get('day', date.today().day(), type=int)
-    if (year == date.today().year() and month == date.today().month() and day > date.today().day()):
-        return make_response("Back to the future?", 418, headers)
-    given_date = date(year, month, day)
-    last_days = request.args.get('last_days', 7, type=int)
+    last_days = int(date_metadata['last_days'])
     episodes_count = Item.query.filter(
         given_date - timedelta(days=last_days) <= Item.play_date
-        ).filter(Item.play_date <= date.today()
+        ).filter(Item.play_date <= datetime.today()
         ).filter(Item.archived == True).count()
     ret = {"uploaded_episodes_in_last_%d_days" % (last_days): episodes_count}
     return make_response(jsonify(ret), 200, headers)
 
-@arcsi.route("/data/episodes_uploaded_weekly", methods=["GET"])
-@auth_token_required
-def get_uploaded_episodes_in_last_x_weeks():
-    year = request.args.get('year', date.today().year(), type=int)
-    if (year > date.today().year()):
+@arcsi.route("/data/episodes_uploaded_weekly", methods=["POST"])
+@roles_required("guest")
+def uploaded_episodes_in_last_x_weeks():
+    date_metadata = request.form.to_dict()
+    from_date = date_metadata['from_date']
+    given_date = datetime.strptime(from_date, '%Y-%m-%d')
+    if (given_date > datetime.today()):
         return make_response("Back to the future?", 418, headers)
-    month = request.args.get('month', date.today().month(), type=int)
-    if (year == date.today().year() and month > date.today().month()):
-        return make_response("Back to the future?", 418, headers)
-    day = request.args.get('day', date.today().day(), type=int)
-    if (year == date.today().year() and month == date.today().month() and day > date.today().day()):
-        return make_response("Back to the future?", 418, headers)
-    given_date = date(year, month, day)
-    last_weeks = request.args.get('last_weeks', 1, type=int)
+    last_weeks = int(date_metadata['last_weeks'])
     episodes_count = Item.query.filter(
         given_date - timedelta(weeks=last_weeks) <= Item.play_date
-        ).filter(Item.play_date <= date.today()
+        ).filter(Item.play_date <= datetime.today()
         ).filter(Item.archived == True).count()
     ret = {"uploaded_episodes_in_last_%d_weeks" % (last_weeks): episodes_count}
     return make_response(jsonify(ret), 200, headers)

--- a/arcsi/api/data.py
+++ b/arcsi/api/data.py
@@ -1,0 +1,20 @@
+from datetime import datetime, timedelta
+
+from flask import jsonify, make_response, request, redirect
+from flask_security import auth_token_required
+
+from . import arcsi
+from arcsi.model.item import Item
+
+headers = {"Content-Type": "application/json"}
+
+@arcsi.route("/data/items_uploaded", methods=["GET"])
+@auth_token_required
+def get_uploaded_items_in_last_x_days():
+    days = request.args.get('days', 7, type=int)
+    item_count = Item.query.filter(
+        datetime.today() - timedelta(days=days) <= Item.play_date
+        ).filter(Item.play_date <= datetime.today()
+        ).filter(Item.archived == True).count()
+    ret = {"item_count": item_count}
+    return make_response(jsonify(ret), 200, headers)

--- a/arcsi/api/data.py
+++ b/arcsi/api/data.py
@@ -17,6 +17,8 @@ def uploaded_episodes_in_last_x_days():
     if (given_date > datetime.today()):
         return make_response("Back to the future?", 418, headers)
     last_days = int(date_metadata['last_days'])
+    if (last_days < 0):
+        return make_response("Please, be postive!", 400, headers)
     episodes_count = Item.query.filter(
         given_date - timedelta(days=last_days) <= Item.play_date
         ).filter(Item.play_date <= datetime.today()
@@ -33,6 +35,8 @@ def uploaded_episodes_in_last_x_weeks():
     if (given_date > datetime.today()):
         return make_response("Back to the future?", 418, headers)
     last_weeks = int(date_metadata['last_weeks'])
+    if (last_weeks < 0):
+        return make_response("Please, be postive!", 400, headers)
     episodes_count = Item.query.filter(
         given_date - timedelta(weeks=last_weeks) <= Item.play_date
         ).filter(Item.play_date <= datetime.today()

--- a/arcsi/api/data.py
+++ b/arcsi/api/data.py
@@ -1,6 +1,6 @@
-from datetime import datetime, timedelta
+from datetime import date, timedelta
 
-from flask import jsonify, make_response, request, redirect
+from flask import jsonify, make_response, request
 from flask_security import auth_token_required
 
 from . import arcsi
@@ -8,13 +8,44 @@ from arcsi.model.item import Item
 
 headers = {"Content-Type": "application/json"}
 
-@arcsi.route("/data/items_uploaded", methods=["GET"])
+@arcsi.route("/data/episodes_uploaded_daily", methods=["GET"])
 @auth_token_required
-def get_uploaded_items_in_last_x_days():
-    days = request.args.get('days', 7, type=int)
-    item_count = Item.query.filter(
-        datetime.today() - timedelta(days=days) <= Item.play_date
-        ).filter(Item.play_date <= datetime.today()
+def get_uploaded_episodes_in_last_x_days():
+    year = request.args.get('year', date.today().year(), type=int)
+    if (year > date.today().year()):
+        return make_response("Back to the future?", 418, headers)
+    month = request.args.get('month', date.today().month(), type=int)
+    if (year == date.today().year() and month > date.today().month()):
+        return make_response("Back to the future?", 418, headers)
+    day = request.args.get('day', date.today().day(), type=int)
+    if (year == date.today().year() and month == date.today().month() and day > date.today().day()):
+        return make_response("Back to the future?", 418, headers)
+    given_date = date(year, month, day)
+    last_days = request.args.get('last_days', 7, type=int)
+    episodes_count = Item.query.filter(
+        given_date - timedelta(days=last_days) <= Item.play_date
+        ).filter(Item.play_date <= date.today()
         ).filter(Item.archived == True).count()
-    ret = {"item_count": item_count}
+    ret = {"uploaded_episodes_in_last_%d_days" % (last_days): episodes_count}
+    return make_response(jsonify(ret), 200, headers)
+
+@arcsi.route("/data/episodes_uploaded_weekly", methods=["GET"])
+@auth_token_required
+def get_uploaded_episodes_in_last_x_weeks():
+    year = request.args.get('year', date.today().year(), type=int)
+    if (year > date.today().year()):
+        return make_response("Back to the future?", 418, headers)
+    month = request.args.get('month', date.today().month(), type=int)
+    if (year == date.today().year() and month > date.today().month()):
+        return make_response("Back to the future?", 418, headers)
+    day = request.args.get('day', date.today().day(), type=int)
+    if (year == date.today().year() and month == date.today().month() and day > date.today().day()):
+        return make_response("Back to the future?", 418, headers)
+    given_date = date(year, month, day)
+    last_weeks = request.args.get('last_weeks', 1, type=int)
+    episodes_count = Item.query.filter(
+        given_date - timedelta(weeks=last_weeks) <= Item.play_date
+        ).filter(Item.play_date <= date.today()
+        ).filter(Item.archived == True).count()
+    ret = {"uploaded_episodes_in_last_%d_weeks" % (last_weeks): episodes_count}
     return make_response(jsonify(ret), 200, headers)

--- a/arcsi/api/item.py
+++ b/arcsi/api/item.py
@@ -97,7 +97,7 @@ def list_items_latest():
     return items_archive_schema.dumps(items.items)
 
 
-@arcsi.route("/item/<id>", methods=["GET"])
+@arcsi.route("/item/<int:id>", methods=["GET"])
 @auth_token_required
 def view_item(id):
     item_query = Item.query.filter_by(id=id)
@@ -289,7 +289,7 @@ def add_item():
             return "Some error happened, check server logs for details. Note that your media may have been uploaded (to DO and/or Azurcast)."
 
 
-@arcsi.route("item/<id>/listen", methods=["GET"])
+@arcsi.route("item/<int:id>/listen", methods=["GET"])
 @auth_token_required
 def listen_play_file(id):
     do = DoArchive()
@@ -301,7 +301,7 @@ def listen_play_file(id):
     return presigned
 
 
-@arcsi.route("/item/<id>/download", methods=["GET"])
+@arcsi.route("/item/<int:id>/download", methods=["GET"])
 @auth_token_required
 def download_play_file(id):
     do = DoArchive()
@@ -313,7 +313,7 @@ def download_play_file(id):
     return redirect(presigned, code=302)
 
 
-@arcsi.route("/item/<id>", methods=["DELETE"])
+@arcsi.route("/item/<int:id>", methods=["DELETE"])
 @roles_required("admin")
 def delete_item(id):
     item_query = Item.query.filter_by(id=id)
@@ -323,7 +323,7 @@ def delete_item(id):
     return make_response("Deleted item successfully", 200, headers)
 
 
-@arcsi.route("/item/<id>/edit", methods=["POST"])
+@arcsi.route("/item/<int:id>/edit", methods=["POST"])
 @roles_required("admin")
 def edit_item(id):
     no_error = True

--- a/arcsi/api/show.py
+++ b/arcsi/api/show.py
@@ -226,7 +226,7 @@ def add_show():
         )
 
 
-@arcsi.route("/show/<id>", methods=["DELETE"])
+@arcsi.route("/show/<int:id>", methods=["DELETE"])
 @roles_required("admin")
 def delete_show(id):
     show_query = Show.query.filter_by(id=id)
@@ -235,7 +235,7 @@ def delete_show(id):
     return make_response("Deleted show successfully", 200, headers)
 
 
-@arcsi.route("/show/<id>/edit", methods=["POST"])
+@arcsi.route("/show/<int:id>/edit", methods=["POST"])
 @roles_required("admin")
 def edit_show(id):
     show_query = Show.query.filter_by(id=id)
@@ -313,7 +313,7 @@ def edit_show(id):
         )
 
 
-@arcsi.route("show/<id>", methods=["GET"])
+@arcsi.route("show/<int:id>", methods=["GET"])
 @auth_token_required
 def view_show(id):
     do = DoArchive()

--- a/arcsi/api/user.py
+++ b/arcsi/api/user.py
@@ -40,7 +40,7 @@ def list_users():
     return many_user_details_schema.dumps(users)
 
 
-@arcsi.route("/user/<id>", methods=["GET"])
+@arcsi.route("/user/<int:id>", methods=["GET"])
 def view_user(id):
     user_query = User.query.filter_by(id=id)
     user = user_query.first_or_404()

--- a/arcsi/static/doc.json
+++ b/arcsi/static/doc.json
@@ -49,7 +49,7 @@
         "tags": [
           "Statistics Request"
         ],
-        "summary": "Returns the number of uploaded episodes during the last x days from the given date",
+        "summary": "Returns the number of uploaded episodes during the last x days from the given date (today, by default)",
         "parameters": [
           {
             "in": "path",
@@ -108,7 +108,7 @@
         "tags": [
           "Statistics Request"
         ],
-        "summary": "Returns the number of uploaded episodes during the last x days from the given date",
+        "summary": "Returns the number of uploaded episodes during the last x weeks from the given date (today, by default)",
         "parameters": [
           {
             "in": "path",

--- a/arcsi/static/doc.json
+++ b/arcsi/static/doc.json
@@ -37,9 +37,131 @@
     {
       "name": "User Request",
       "description": "API for requesting and return User details"
+    },
+    {
+      "name": "Statistics Request",
+      "description": "API for requesting and return Statistics"
     }
   ],
   "paths": {
+    "/data/episodes_uploaded_daily?year={year}&month={month}&day={day}&last_days={last_days}": {
+      "get": {
+        "tags": [
+          "Statistics Request"
+        ],
+        "summary": "Returns the number of uploaded episodes during the last x days from the given date",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "year",
+            "required": true,
+            "description": "default: current year",
+            "type": "int"
+          },
+          {
+            "in": "path",
+            "name": "month",
+            "required": true,
+            "description": "default: current month",
+            "type": "int"
+          },
+          {
+            "in": "path",
+            "name": "day",
+            "required": true,
+            "description": "default: current day",
+            "type": "int"
+          },
+          {
+            "in": "path",
+            "name": "last_days",
+            "required": true,
+            "description": "default: 7",
+            "type": "int"
+          }
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "type": "object",
+                "properties": {
+                    "uploaded_episodes_in_last_x_days": {
+                        "type": "int"
+                    }
+                }
+              }
+            }
+          },
+          "418": {
+            "description": "Back to the future?"
+          }
+        }
+      }
+    },
+    "/data/episodes_uploaded_weekly?year={year}&month={month}&day={day}&last_weeks={last_weeks}": {
+      "get": {
+        "tags": [
+          "Statistics Request"
+        ],
+        "summary": "Returns the number of uploaded episodes during the last x days from the given date",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "year",
+            "required": true,
+            "description": "default: current year",
+            "type": "int"
+          },
+          {
+            "in": "path",
+            "name": "month",
+            "required": true,
+            "description": "default: current month",
+            "type": "int"
+          },
+          {
+            "in": "path",
+            "name": "day",
+            "required": true,
+            "description": "default: current day",
+            "type": "int"
+          },
+          {
+            "in": "path",
+            "name": "last_weeks",
+            "required": true,
+            "description": "default: 1",
+            "type": "int"
+          }
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "type": "object",
+                "properties": {
+                    "uploaded_episodes_in_last_x_weeks": {
+                        "type": "int"
+                    }
+                }
+              }
+            }
+          },
+          "418": {
+            "description": "Back to the future?"
+          }
+        }
+      }
+    },
     "/users/all": {
       "get": {
         "tags": [

--- a/arcsi/static/doc.json
+++ b/arcsi/static/doc.json
@@ -97,6 +97,9 @@
               }
             }
           },
+          "400": {
+            "description": "Please, be postive!"
+          },
           "418": {
             "description": "Back to the future?"
           }
@@ -155,6 +158,9 @@
                 }
               }
             }
+          },
+          "400": {
+            "description": "Please, be postive!"
           },
           "418": {
             "description": "Back to the future?"

--- a/arcsi/templates/base.html
+++ b/arcsi/templates/base.html
@@ -38,6 +38,7 @@
           
           <div class="adminmenu">
             {% if current_user.is_authenticated %}
+            <a href="{{ url_for('router.view_data') }}" title="Statistics"><i class="fa fa-database"></i></a>
             <a href="{{ url_for('router.view_user') }}" title="Profile"><i class="far fa-user-circle"></i></a>
             <a href="{{ url_for('security.logout') }}" title="Logout"><i class="fas fa-sign-out-alt"></i></a>
             {% else %}

--- a/arcsi/templates/data/uploaded_episodes_daily.html
+++ b/arcsi/templates/data/uploaded_episodes_daily.html
@@ -1,0 +1,16 @@
+{% extends 'base.html' %}
+
+{% block header %}
+<h2>{% block title %}Uploaded episodes during last x days{% endblock %}</h2>
+{% endblock %}
+
+{% block content %}
+<form action="{{ url_for('arcsi.uploaded_episodes_in_last_x_days') }}" method="post" enctype="multipart/form-data">
+    <label for="from_date">From date</label>
+    <input type="date" name="from_date" id="from_date">
+
+    <label for="last_days">how many days?</label>
+    <input name="last_days" id="last_days" value="{{ last_days }}">
+    <input type="submit" value="Query">
+</form>
+{% endblock %}

--- a/arcsi/templates/data/uploaded_episodes_weekly.html
+++ b/arcsi/templates/data/uploaded_episodes_weekly.html
@@ -1,0 +1,16 @@
+{% extends 'base.html' %}
+
+{% block header %}
+<h3>{% block title %}Uploaded episodes during last x weeks{% endblock %}</h3>
+{% endblock %}
+
+{% block content %}
+<form action="{{ url_for('arcsi.uploaded_episodes_in_last_x_weeks') }}" method="post" enctype="multipart/form-data">
+    <label for="from_date">From date</label>
+    <input type="date" name="from_date" id="from_date">
+
+    <label for="last_weeks">how many weeks?</label>
+    <input name="last_weeks" id="last_weeks" value="{{ last_weeks }}">
+    <input type="submit" value="Query">
+</form>
+{% endblock %}

--- a/arcsi/templates/data/view.html
+++ b/arcsi/templates/data/view.html
@@ -1,0 +1,11 @@
+{% extends 'base.html' %}
+
+{% block header %}
+<h2>{% block title %}Data statistics{% endblock %}</h2>
+<h4>
+    <a href="{{ url_for('router.uploaded_episodes_in_last_x_days') }}">Daily uploaded episodes stats</a>
+</h4>
+<h4>
+    <a href="{{ url_for('router.uploaded_episodes_in_last_x_weeks') }}">Weekly uploaded episodes stats</a>
+</h4>
+{% endblock %}

--- a/arcsi/view/__init__.py
+++ b/arcsi/view/__init__.py
@@ -7,3 +7,4 @@ from .archive import *
 from .item import *
 from .show import *
 from .user import *
+from .data import *

--- a/arcsi/view/data.py
+++ b/arcsi/view/data.py
@@ -1,0 +1,23 @@
+import requests
+
+from flask import current_app as app
+from flask import render_template, request, url_for
+from flask_login import current_user
+from flask_security import login_required, roles_required
+
+from arcsi.view import router
+
+@router.route("/data")
+@login_required
+def view_data():
+    return render_template("data/view.html")
+
+@router.route("/data/latest_uploaded_episodes_daily")
+@login_required
+def uploaded_episodes_in_last_x_days():
+    return render_template("data/uploaded_episodes_daily.html")
+
+@router.route("/data/latest_uploaded_episodes_weekly")
+@login_required
+def uploaded_episodes_in_last_x_weeks():
+    return render_template("data/uploaded_episodes_weekly.html")


### PR DESCRIPTION
Added 2 new API endpoints which returns the sum of the uploaded items during the last x days/weeks from the given date.
Introduced new statistics related view pages on Arcsi UI, to be able to reach these info without Postman requests.
Updated the Swagger docs according to this.
Also added some constraints on API URL's variables, in order to prevent incorrect API calls (changes in item.py, show.py, user.py).