### PR TITLE
Changing flask-security to flask-security-too

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -88,7 +88,7 @@ jobs:
     - name: Robustness Test
       run: |
         cd test/postman/
-        newman run robustness_test.postman_collection.json -e test.postman_environment.json -n 200 -k
+        newman run robustness_test.postman_collection.json -e test.postman_environment.json -n 50 -k
 
     - name: Upload logs
       uses: actions/upload-artifact@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -88,7 +88,7 @@ jobs:
     - name: Robustness Test
       run: |
         cd test/postman/
-        newman run robustness_test.postman_collection.json -e test.postman_environment.json -n 1000 -k
+        newman run robustness_test.postman_collection.json -e test.postman_environment.json -n 200 -k
 
     - name: Upload logs
       uses: actions/upload-artifact@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -65,9 +65,6 @@ jobs:
     - name: Run the application and Postman's tests
       run: |
         gunicorn -b localhost:5000 -w 4 "arcsi:create_app('../config_ci.py')" --daemon --log-file aguni.log --log-level debug
-        cd test/postman/
-        newman run functional_test.postman_collection.json -e test.postman_environment.json -k
-        newman run robustness_test.postman_collection.json -e test.postman_environment.json -n 1000 -k
       env:
         FLASK_ENV: development
         UPLOAD_FOLDER: "uploads"
@@ -82,6 +79,16 @@ jobs:
         POSTGRES_PASSWORD: p0stgr3s
         POSTGRES_DB: arcsi
         CI: true
+    
+    - name: Functional Test
+      run: |
+        cd test/postman/
+        newman run functional_test.postman_collection.json -e test.postman_environment.json -k
+  
+    - name: Robustness Test
+      run: |
+        cd test/postman/
+        newman run robustness_test.postman_collection.json -e test.postman_environment.json -n 1000 -k
 
     - name: Upload logs
       uses: actions/upload-artifact@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -88,7 +88,7 @@ jobs:
     - name: Robustness Test
       run: |
         cd test/postman/
-        newman run robustness_test.postman_collection.json -e test.postman_environment.json -n 50 -k
+        newman run robustness_test.postman_collection.json -e test.postman_environment.json -n 20 -k
 
     - name: Upload logs
       uses: actions/upload-artifact@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -65,7 +65,9 @@ jobs:
     - name: Run the application and Postman's tests
       run: |
         gunicorn -b localhost:5000 -w 4 "arcsi:create_app('../config_ci.py')" --daemon --log-file aguni.log --log-level debug
-        cd test/postman/ && newman run test.postman_collection.json -e test.postman_environment.json -k
+        cd test/postman/
+        newman run functional_test.postman_collection.json -e test.postman_environment.json -k
+        newman run robustness_test.postman_collection.json -e test.postman_environment.json -n 1000 -k
       env:
         FLASK_ENV: development
         UPLOAD_FOLDER: "uploads"

--- a/arcsi/model/user.py
+++ b/arcsi/model/user.py
@@ -14,7 +14,7 @@ class User(db.Model, UserMixin):
     butt_user = db.Column(db.String())
     butt_pw = db.Column(db.String(128))
     roles = db.relationship(
-        "Role", secondary=roles_users, backref=db.backref("users"), lazy="dynamic"
+        "Role", secondary=roles_users, backref=db.backref("users")
     )
     shows = db.relationship(
         "Show",

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,7 @@ Flask-Mail==0.9.1
 flask-marshmallow==0.12.0
 Flask-Migrate==2.5.2
 Flask-Principal==0.4.0
-Flask-Security==3.0.0
+Flask-Security==3.0.2
 Flask-SQLAlchemy==2.4.2
 Flask-WTF==0.14.3
 flowjs==0.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,7 @@ Flask-Mail==0.9.1
 flask-marshmallow==0.12.0
 Flask-Migrate==2.5.2
 Flask-Principal==0.4.0
-Flask-Security-Too==3.0.2
+Flask-Security-Too==3.2.0
 Flask-SQLAlchemy==2.4.2
 Flask-WTF==0.14.3
 flowjs==0.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,7 @@ Flask-Mail==0.9.1
 flask-marshmallow==0.12.0
 Flask-Migrate==2.5.2
 Flask-Principal==0.4.0
-Flask-Security==3.0.2
+Flask-Security-Too==3.0.2
 Flask-SQLAlchemy==2.4.2
 Flask-WTF==0.14.3
 flowjs==0.1.1

--- a/test/postman/functional_test.postman_collection.json
+++ b/test/postman/functional_test.postman_collection.json
@@ -1,7 +1,7 @@
 {
 	"info": {
-		"_postman_id": "c6974ba5-bf1f-4b09-a1c9-365cbd75850e",
-		"name": "CI test",
+		"_postman_id": "e661c83e-0370-4481-8dfe-d0082bbf878e",
+		"name": "CI test (functional)",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
 	"item": [

--- a/test/postman/robustness_test.postman_collection.json
+++ b/test/postman/robustness_test.postman_collection.json
@@ -264,8 +264,8 @@
 							"    })\r",
 							"})\r",
 							"\r",
-							"pm.test(\"Episodes number is 0\", function() {\r",
-							"    pm.expect(items.length).to.equal(0)\r",
+							"pm.test(\"Episodes number is 4\", function() {\r",
+							"    pm.expect(items.length).to.equal(4)\r",
 							"})"
 						],
 						"type": "text/javascript"

--- a/test/postman/robustness_test.postman_collection.json
+++ b/test/postman/robustness_test.postman_collection.json
@@ -1,0 +1,1149 @@
+{
+	"info": {
+		"_postman_id": "1bb97ca4-f02a-4a9b-a2ae-1a8fb07096ff",
+		"name": "CI test (robustness)",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+	},
+	"item": [
+		{
+			"name": "Get Shows (1, list_shows())",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"Status code is 200\", function () {\r",
+							"    pm.response.to.have.status(200)\r",
+							"})\r",
+							"\r",
+							"pm.test(\"Content-Type is text/html\", function() {\r",
+							"    pm.response.to.be.header(\"Content-Type\", \"text/html; charset=utf-8\")\r",
+							"})\r",
+							"\r",
+							"pm.test(\"API responds within 5 sec (\" + pm.response.responseTime + \" msec)\", () => {\r",
+							"    const expectedTimeInMilliseconds = 5000;\r",
+							"    pm.expect(pm.response.responseTime).to.be.lessThan(\r",
+							"        expectedTimeInMilliseconds + 1,\r",
+							"        `Response came in ${pm.response.responseTime} ms`);\r",
+							"});\r",
+							"\r",
+							"const shows = JSON.parse(responseBody)\r",
+							"pm.test(\"ResponseBody fields are correct!\", function() {\r",
+							"    pm.expect(shows).to.be.an(\"array\")\r",
+							"    shows.forEach(function(show) {\r",
+							"        pm.expect(show).to.be.an(\"object\")\r",
+							"        pm.expect(show.items).to.be.an(\"array\")\r",
+							"        show.items.forEach(function(item) {\r",
+							"            pm.expect(item).to.be.an(\"object\")\r",
+							"            pm.expect(item.archived).to.be.an(\"boolean\")\r",
+							"            pm.expect(item.name).to.be.an(\"string\")\r",
+							"            pm.expect(item.description).to.be.an(\"string\")\r",
+							"            pm.expect(item.play_date).to.be.an(\"string\")\r",
+							"            pm.expect(item.image_url).to.be.an(\"string\")\r",
+							"            if (item.play_file_name != null) {\r",
+							"                pm.expect(item.play_file_name).to.be.an(\"string\")\r",
+							"            }\r",
+							"            pm.expect(item.id).to.be.an(\"number\")\r",
+							"            pm.expect(item.number).to.be.an(\"number\")\r",
+							"            pm.expect(item.download_count).to.be.an(\"number\")\r",
+							"        })\r",
+							"        pm.expect(show.users).to.be.an(\"array\")\r",
+							"        show.users.forEach(function(user) {\r",
+							"            pm.expect(user).to.be.an(\"object\")\r",
+							"            pm.expect(user.name).to.be.an(\"string\")\r",
+							"            pm.expect(user.email).to.be.an(\"string\")\r",
+							"            pm.expect(user.id).to.be.an(\"number\")\r",
+							"        })\r",
+							"        pm.expect(show.active).to.be.an(\"boolean\")\r",
+							"        pm.expect(show.archive_lahmastore).to.be.an(\"boolean\")\r",
+							"        pm.expect(show.archive_mixcloud).to.be.an(\"boolean\")\r",
+							"        pm.expect(show.name).to.be.an(\"string\")\r",
+							"        pm.expect(show.description).to.be.an(\"string\")\r",
+							"        pm.expect(show.language).to.be.an(\"string\")\r",
+							"        pm.expect(show.playlist_name).to.be.an(\"string\")\r",
+							"        pm.expect(show.archive_lahmastore_base_url).to.be.an(\"string\")\r",
+							"        if (show.archive_mixcloud_base_url != null) {\r",
+							"            pm.expect(show.archive_mixcloud_base_url).to.be.an(\"string\")\r",
+							"        }\r",
+							"        pm.expect(show.cover_image_url).to.be.an(\"string\")\r",
+							"        pm.expect(show.start).to.be.an(\"string\")\r",
+							"        pm.expect(show.end).to.be.an(\"string\")\r",
+							"        pm.expect(show.day).to.be.an(\"number\")\r",
+							"        pm.expect(show.frequency).to.be.an(\"number\")\r",
+							"        pm.expect(show.week).to.be.an(\"number\")\r",
+							"        pm.expect(show.id).to.be.an(\"number\")\r",
+							"    })\r",
+							"})\r",
+							"\r",
+							"pm.test(\"Shows number is 1\", function() {\r",
+							"    pm.expect(shows.length).to.equal(1)\r",
+							"})"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "GET",
+				"header": [
+					{
+						"key": "Authentication-Token",
+						"value": "{{api_token}}",
+						"type": "text"
+					}
+				],
+				"url": {
+					"raw": "{{url}}/show/all",
+					"host": [
+						"{{url}}"
+					],
+					"path": [
+						"show",
+						"all"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Get Show (view_show(id))",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"Status code is 200\", function () {\r",
+							"    pm.response.to.have.status(200)\r",
+							"})\r",
+							"\r",
+							"pm.test(\"Content-Type is application/json\", function() {\r",
+							"    pm.response.to.be.header(\"Content-Type\", \"application/json\")\r",
+							"})\r",
+							"\r",
+							"pm.test(\"API responds within 5 sec (\" + pm.response.responseTime + \" msec)\", () => {\r",
+							"    const expectedTimeInMilliseconds = 5000;\r",
+							"    pm.expect(pm.response.responseTime).to.be.lessThan(\r",
+							"        expectedTimeInMilliseconds + 1,\r",
+							"        `Response came in ${pm.response.responseTime} ms`);\r",
+							"});\r",
+							"\r",
+							"const show = JSON.parse(responseBody)\r",
+							"pm.test(\"ResponseBody is OK!\", function() {\r",
+							"    pm.expect(show).to.be.an(\"object\")\r",
+							"    pm.expect(show.items).to.be.an(\"array\")\r",
+							"    show.items.forEach(function(item) {\r",
+							"        pm.expect(item).to.be.an(\"object\")\r",
+							"        pm.expect(item.archived).to.be.an(\"boolean\")\r",
+							"        pm.expect(item.name).to.be.an(\"string\")\r",
+							"        pm.expect(item.description).to.be.an(\"string\")\r",
+							"        pm.expect(item.play_date).to.be.an(\"string\")\r",
+							"        pm.expect(item.image_url).to.be.an(\"string\")\r",
+							"        if (item.play_file_name != null) {\r",
+							"            pm.expect(item.play_file_name).to.be.an(\"string\")\r",
+							"        }\r",
+							"        pm.expect(item.id).to.be.an(\"number\")\r",
+							"        pm.expect(item.number).to.be.an(\"number\")\r",
+							"        pm.expect(item.download_count).to.be.an(\"number\")\r",
+							"    })\r",
+							"    pm.expect(show.users).to.be.an(\"array\")\r",
+							"    show.users.forEach(function(user) {\r",
+							"        pm.expect(user).to.be.an(\"object\")\r",
+							"        pm.expect(user.name).to.be.an(\"string\")\r",
+							"        pm.expect(user.email).to.be.an(\"string\")\r",
+							"        pm.expect(user.id).to.be.an(\"number\")\r",
+							"    })\r",
+							"    pm.expect(show.active).to.be.an(\"boolean\")\r",
+							"    pm.expect(show.archive_lahmastore).to.be.an(\"boolean\")\r",
+							"    pm.expect(show.archive_mixcloud).to.be.an(\"boolean\")\r",
+							"    pm.expect(show.name).to.be.an(\"string\")\r",
+							"    pm.expect(show.description).to.be.an(\"string\")\r",
+							"    pm.expect(show.language).to.be.an(\"string\")\r",
+							"    pm.expect(show.playlist_name).to.be.an(\"string\")\r",
+							"    pm.expect(show.archive_lahmastore_base_url).to.be.an(\"string\")\r",
+							"    if (show.archive_mixcloud_base_url != null) {\r",
+							"        pm.expect(show.archive_mixcloud_base_url).to.be.an(\"string\")\r",
+							"    }\r",
+							"    pm.expect(show.cover_image_url).to.be.an(\"string\")\r",
+							"    pm.expect(show.start).to.be.an(\"string\")\r",
+							"    pm.expect(show.end).to.be.an(\"string\")\r",
+							"    pm.expect(show.day).to.be.an(\"number\")\r",
+							"    pm.expect(show.frequency).to.be.an(\"number\")\r",
+							"    pm.expect(show.week).to.be.an(\"number\")\r",
+							"    pm.expect(show.id).to.be.an(\"number\")\r",
+							"})"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "GET",
+				"header": [
+					{
+						"key": "Authentication-Token",
+						"value": "{{api_token}}",
+						"type": "text"
+					}
+				],
+				"url": {
+					"raw": "{{url}}/show/:id",
+					"host": [
+						"{{url}}"
+					],
+					"path": [
+						"show",
+						":id"
+					],
+					"variable": [
+						{
+							"key": "id",
+							"value": "{{new_show_id}}"
+						}
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Get Items (0, list_items())",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"Status code is 200\", function () {\r",
+							"    pm.response.to.have.status(200)\r",
+							"})\r",
+							"\r",
+							"pm.test(\"Content-Type is text/html\", function() {\r",
+							"    pm.response.to.be.header(\"Content-Type\", \"text/html; charset=utf-8\")\r",
+							"})\r",
+							"\r",
+							"pm.test(\"API responds within 5 sec (\" + pm.response.responseTime + \" msec)\", () => {\r",
+							"    const expectedTimeInMilliseconds = 5000;\r",
+							"    pm.expect(pm.response.responseTime).to.be.lessThan(\r",
+							"        expectedTimeInMilliseconds + 1,\r",
+							"        `Response came in ${pm.response.responseTime} ms`);\r",
+							"});\r",
+							"\r",
+							"const items = JSON.parse(responseBody)\r",
+							"pm.test(\"ResponseBody fields are correct!\", function() {\r",
+							"    pm.expect(items).to.be.an(\"array\")\r",
+							"    items.forEach(function(item) {\r",
+							"        pm.expect(item).to.be.an(\"object\")\r",
+							"        pm.expect(item.shows).to.be.an(\"array\")\r",
+							"        item.shows.forEach(function(show){\r",
+							"            pm.expect(show).to.be.an(\"object\")\r",
+							"            pm.expect(show.name).to.be.an(\"string\")\r",
+							"            pm.expect(show.archive_lahmastore_base_url).to.be.an(\"string\")\r",
+							"            pm.expect(show.id).to.be.an(\"number\")\r",
+							"        })\r",
+							"        pm.expect(item.live).to.be.an(\"boolean\")\r",
+							"        pm.expect(item.broadcast).to.be.an(\"boolean\")\r",
+							"        if (item.airing != null) {\r",
+							"            pm.expect(item.airing).to.be.an(\"boolean\")\r",
+							"        }\r",
+							"        pm.expect(item.archived).to.be.an(\"boolean\")\r",
+							"        pm.expect(item.archive_lahmastore).to.be.an(\"boolean\")\r",
+							"        pm.expect(item.archive_mixcloud).to.be.an(\"boolean\")\r",
+							"        pm.expect(item.name).to.be.an(\"string\")\r",
+							"        pm.expect(item.name_slug).to.be.an(\"string\")\r",
+							"        pm.expect(item.description).to.be.an(\"string\")\r",
+							"        pm.expect(item.language).to.be.an(\"string\")\r",
+							"        pm.expect(item.play_date).to.be.an(\"string\")\r",
+							"        pm.expect(item.archive_lahmastore_canonical_url).to.be.an(\"string\")\r",
+							"        pm.expect(item.archive_mixcloud_canonical_url).to.be.an(\"string\")\r",
+							"        pm.expect(item.image_url).to.be.an(\"string\")\r",
+							"        if (item.play_file_name != null) {\r",
+							"            pm.expect(item.play_file_name).to.be.an(\"string\")\r",
+							"        }\r",
+							"        pm.expect(item.uploader).to.be.an(\"string\")\r",
+							"        pm.expect(item.id).to.be.an(\"number\")\r",
+							"        pm.expect(item.number).to.be.an(\"number\")\r",
+							"        pm.expect(item.download_count).to.be.an(\"number\")\r",
+							"    })\r",
+							"})\r",
+							"\r",
+							"pm.test(\"Episodes number is 0\", function() {\r",
+							"    pm.expect(items.length).to.equal(0)\r",
+							"})"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "GET",
+				"header": [
+					{
+						"key": "Authentication-Token",
+						"value": "{{api_token}}",
+						"type": "text"
+					}
+				],
+				"url": {
+					"raw": "{{url}}/item/all",
+					"host": [
+						"{{url}}"
+					],
+					"path": [
+						"item",
+						"all"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "View Item (4, view_item(id))",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"Status code is 200\", function () {\r",
+							"    pm.response.to.have.status(200)\r",
+							"})\r",
+							"\r",
+							"pm.test(\"Content-Type is application/json\", function() {\r",
+							"    pm.response.to.be.header(\"Content-Type\", \"application/json\")\r",
+							"})\r",
+							"\r",
+							"pm.test(\"API responds within 5 sec (\" + pm.response.responseTime + \" msec)\", () => {\r",
+							"    const expectedTimeInMilliseconds = 5000;\r",
+							"    pm.expect(pm.response.responseTime).to.be.lessThan(\r",
+							"        expectedTimeInMilliseconds + 1,\r",
+							"        `Response came in ${pm.response.responseTime} ms`);\r",
+							"});\r",
+							"\r",
+							"const item = JSON.parse(responseBody)\r",
+							"pm.test(\"ResponseBody fields are correct!\", function() {\r",
+							"    pm.expect(item).to.be.an(\"object\")\r",
+							"    pm.expect(item.shows).to.be.an(\"array\")\r",
+							"    item.shows.forEach(function(show) {\r",
+							"        pm.expect(show).to.be.an(\"object\")\r",
+							"        pm.expect(show.name).to.be.an(\"string\")\r",
+							"        pm.expect(show.archive_lahmastore_base_url).to.be.an(\"string\")\r",
+							"        pm.expect(show.id).to.be.an(\"number\")\r",
+							"    })\r",
+							"    pm.expect(item.live).to.be.an(\"boolean\")\r",
+							"    pm.expect(item.broadcast).to.be.an(\"boolean\")\r",
+							"    if (item.airing != null) {\r",
+							"        pm.expect(item.airing).to.be.an(\"boolean\")\r",
+							"    }\r",
+							"    pm.expect(item.archived).to.be.an(\"boolean\")\r",
+							"    pm.expect(item.archive_lahmastore).to.be.an(\"boolean\")\r",
+							"    pm.expect(item.archive_mixcloud).to.be.an(\"boolean\")\r",
+							"    pm.expect(item.name).to.be.an(\"string\")\r",
+							"    pm.expect(item.name_slug).to.be.an(\"string\")\r",
+							"    pm.expect(item.description).to.be.an(\"string\")\r",
+							"    pm.expect(item.language).to.be.an(\"string\")\r",
+							"    pm.expect(item.play_date).to.be.an(\"string\")\r",
+							"    pm.expect(item.archive_lahmastore_canonical_url).to.be.an(\"string\")\r",
+							"    pm.expect(item.archive_mixcloud_canonical_url).to.be.an(\"string\")\r",
+							"    pm.expect(item.image_url).to.be.an(\"string\")\r",
+							"    if (item.play_file_name != null) {\r",
+							"        pm.expect(item.play_file_name).to.be.an(\"string\")\r",
+							"    }\r",
+							"    pm.expect(item.uploader).to.be.an(\"string\")\r",
+							"    pm.expect(item.id).to.be.an(\"number\")\r",
+							"    pm.expect(item.number).to.be.an(\"number\")\r",
+							"    pm.expect(item.download_count).to.be.an(\"number\")\r",
+							"})"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "GET",
+				"header": [
+					{
+						"key": "Authentication-Token",
+						"value": "{{api_token}}",
+						"type": "text"
+					}
+				],
+				"url": {
+					"raw": "{{url}}/item/:id",
+					"host": [
+						"{{url}}"
+					],
+					"path": [
+						"item",
+						":id"
+					],
+					"variable": [
+						{
+							"key": "id",
+							"value": "{{new_item_id}}"
+						}
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Get Latest Items (list_items_latest())",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"Status code is 200\", function () {\r",
+							"    pm.response.to.have.status(200)\r",
+							"})\r",
+							"\r",
+							"pm.test(\"Content-Type is text/html\", function() {\r",
+							"    pm.response.to.be.header(\"Content-Type\", \"text/html; charset=utf-8\")\r",
+							"})\r",
+							"\r",
+							"const jsonData = JSON.parse(responseBody)\r",
+							"pm.test(\"ResponseBody fields are correct!\", function() {\r",
+							"    pm.expect(jsonData).to.be.an(\"array\")\r",
+							"    jsonData.forEach(function(item) {\r",
+							"        pm.expect(item).to.be.an(\"object\")\r",
+							"        pm.expect(item.shows).to.be.an(\"array\")\r",
+							"        item.shows.forEach(function(show){\r",
+							"            pm.expect(show).to.be.an(\"object\")\r",
+							"            pm.expect(show.name).to.be.an(\"string\")\r",
+							"            pm.expect(show.archive_lahmastore_base_url).to.be.an(\"string\")\r",
+							"            pm.expect(show.id).to.be.an(\"number\")\r",
+							"        })\r",
+							"        pm.expect(item.archived).to.be.an(\"boolean\")\r",
+							"        pm.expect(item.name).to.be.an(\"string\")\r",
+							"        pm.expect(item.name_slug).to.be.an(\"string\")\r",
+							"        pm.expect(item.description).to.be.an(\"string\")\r",
+							"        pm.expect(item.language).to.be.an(\"string\")\r",
+							"        pm.expect(item.play_date).to.be.an(\"string\")\r",
+							"        pm.expect(item.image_url).to.be.an(\"string\")\r",
+							"        if (item.play_file_name != null) {\r",
+							"            pm.expect(item.play_file_name).to.be.an(\"string\")\r",
+							"        }\r",
+							"        pm.expect(item.id).to.be.an(\"number\")\r",
+							"        pm.expect(item.number).to.be.an(\"number\")\r",
+							"        pm.expect(item.download_count).to.be.an(\"number\")\r",
+							"    })\r",
+							"})"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "GET",
+				"header": [
+					{
+						"key": "Authentication-Token",
+						"value": "{{api_token}}",
+						"type": "text"
+					}
+				],
+				"url": {
+					"raw": "{{url}}/item/latest?page=1&size=12",
+					"host": [
+						"{{url}}"
+					],
+					"path": [
+						"item",
+						"latest"
+					],
+					"query": [
+						{
+							"key": "page",
+							"value": "1"
+						},
+						{
+							"key": "size",
+							"value": "12"
+						}
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Search Item (search_item())",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"Status code is 200\", function () {\r",
+							"    pm.response.to.have.status(200)\r",
+							"})\r",
+							"\r",
+							"pm.test(\"Content-Type is text/html\", function() {\r",
+							"    pm.response.to.be.header(\"Content-Type\", \"text/html; charset=utf-8\")\r",
+							"})\r",
+							"\r",
+							"pm.test(\"Status code is 200\", function () {\r",
+							"    pm.response.to.have.status(200)\r",
+							"})\r",
+							"\r",
+							"pm.test(\"Content-Type is text/html; charset=utf-8\", function() {\r",
+							"    pm.response.to.be.header(\"Content-Type\", \"text/html; charset=utf-8\")\r",
+							"})\r",
+							"\r",
+							"const jsonData = JSON.parse(responseBody)\r",
+							"pm.test(\"ResponseBody fields are correct!\", function() {\r",
+							"    pm.expect(jsonData).to.be.an(\"array\")\r",
+							"    jsonData.forEach(function(item) {\r",
+							"        pm.expect(item).to.be.an(\"object\")\r",
+							"        pm.expect(item.shows).to.be.an(\"array\")\r",
+							"        item.shows.forEach(function(show){\r",
+							"            pm.expect(show).to.be.an(\"object\")\r",
+							"            pm.expect(show.name).to.be.an(\"string\")\r",
+							"            pm.expect(show.archive_lahmastore_base_url).to.be.an(\"string\")\r",
+							"            pm.expect(show.id).to.be.an(\"number\")\r",
+							"        })\r",
+							"        pm.expect(item.live).to.be.an(\"boolean\")\r",
+							"        pm.expect(item.broadcast).to.be.an(\"boolean\")\r",
+							"        if (item.airing != null) {\r",
+							"            pm.expect(item.airing).to.be.an(\"boolean\")\r",
+							"        }\r",
+							"        pm.expect(item.archived).to.be.an(\"boolean\")\r",
+							"        pm.expect(item.archive_lahmastore).to.be.an(\"boolean\")\r",
+							"        pm.expect(item.archive_mixcloud).to.be.an(\"boolean\")\r",
+							"        pm.expect(item.name).to.be.an(\"string\")\r",
+							"        pm.expect(item.name_slug).to.be.an(\"string\")\r",
+							"        pm.expect(item.description).to.be.an(\"string\")\r",
+							"        pm.expect(item.language).to.be.an(\"string\")\r",
+							"        pm.expect(item.play_date).to.be.an(\"string\")\r",
+							"        pm.expect(item.archive_lahmastore_canonical_url).to.be.an(\"string\")\r",
+							"        pm.expect(item.archive_mixcloud_canonical_url).to.be.an(\"string\")\r",
+							"        pm.expect(item.image_url).to.be.an(\"string\")\r",
+							"        if (item.play_file_name != null) {\r",
+							"            pm.expect(item.play_file_name).to.be.an(\"string\")\r",
+							"        }\r",
+							"        pm.expect(item.uploader).to.be.an(\"string\")\r",
+							"        pm.expect(item.id).to.be.an(\"number\")\r",
+							"        pm.expect(item.number).to.be.an(\"number\")\r",
+							"        pm.expect(item.download_count).to.be.an(\"number\")\r",
+							"    })\r",
+							"})"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "GET",
+				"header": [
+					{
+						"key": "Authentication-Token",
+						"value": "{{api_token}}",
+						"type": "text"
+					}
+				],
+				"url": {
+					"raw": "{{url}}/item/search?param=item&page=1&size=12",
+					"host": [
+						"{{url}}"
+					],
+					"path": [
+						"item",
+						"search"
+					],
+					"query": [
+						{
+							"key": "param",
+							"value": "item"
+						},
+						{
+							"key": "page",
+							"value": "1"
+						},
+						{
+							"key": "size",
+							"value": "12"
+						}
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "View Item with Slug (view_episode_archive(show_slug, item_slug))",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"Status code is 200\", function () {\r",
+							"    pm.response.to.have.status(200)\r",
+							"})\r",
+							"\r",
+							"pm.test(\"Content-Type is application/json\", function() {\r",
+							"    pm.response.to.be.header(\"Content-Type\", \"application/json\")\r",
+							"})\r",
+							"\r",
+							"const item = JSON.parse(responseBody)\r",
+							"pm.test(\"ResponseBody fields are correct!\", function() {\r",
+							"    pm.expect(item).to.be.an(\"object\")\r",
+							"    pm.expect(item.shows).to.be.an(\"array\")\r",
+							"    item.shows.forEach(function(show){\r",
+							"        pm.expect(show).to.be.an(\"object\")\r",
+							"        pm.expect(show.name).to.be.an(\"string\")\r",
+							"        pm.expect(show.archive_lahmastore_base_url).to.be.an(\"string\")\r",
+							"        pm.expect(show.id).to.be.an(\"number\")\r",
+							"    })\r",
+							"    pm.expect(item.archived).to.be.an(\"boolean\")\r",
+							"    pm.expect(item.name).to.be.an(\"string\")\r",
+							"    pm.expect(item.name_slug).to.be.an(\"string\")\r",
+							"    pm.expect(item.description).to.be.an(\"string\")\r",
+							"    pm.expect(item.language).to.be.an(\"string\")\r",
+							"    pm.expect(item.play_date).to.be.an(\"string\")\r",
+							"    pm.expect(item.image_url).to.be.an(\"string\")\r",
+							"    if (item.play_file_name != null) {\r",
+							"        pm.expect(item.play_file_name).to.be.an(\"string\")\r",
+							"    }\r",
+							"    pm.expect(item.id).to.be.an(\"number\")\r",
+							"    pm.expect(item.number).to.be.an(\"number\")\r",
+							"    pm.expect(item.download_count).to.be.an(\"number\")\r",
+							"})"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "GET",
+				"header": [
+					{
+						"key": "Authentication-Token",
+						"value": "{{api_token}}",
+						"type": "text"
+					}
+				],
+				"url": {
+					"raw": "{{url}}/show/:show_slug/item/:item_slug",
+					"host": [
+						"{{url}}"
+					],
+					"path": [
+						"show",
+						":show_slug",
+						"item",
+						":item_slug"
+					],
+					"variable": [
+						{
+							"key": "show_slug",
+							"value": "{{new_show_slug}}"
+						},
+						{
+							"key": "item_slug",
+							"value": "example_item1"
+						}
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Get Shows Paginated (list_shows_page())",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"Status code is 200\", function () {\r",
+							"    pm.response.to.have.status(200)\r",
+							"})\r",
+							"\r",
+							"pm.test(\"Content-Type is text/html\", function() {\r",
+							"    pm.response.to.be.header(\"Content-Type\", \"text/html; charset=utf-8\")\r",
+							"})\r",
+							"\r",
+							"const jsonData = JSON.parse(responseBody)\r",
+							"pm.test(\"ResponseBody fields are correct!\", function() {\r",
+							"    pm.expect(jsonData).to.be.an(\"array\")\r",
+							"    jsonData.forEach(function(show) {\r",
+							"        pm.expect(show).to.be.an(\"object\")\r",
+							"        pm.expect(show.active).to.be.an(\"boolean\")\r",
+							"        pm.expect(show.name).to.be.an(\"string\")\r",
+							"        pm.expect(show.description).to.be.an(\"string\")\r",
+							"        pm.expect(show.playlist_name).to.be.an(\"string\")\r",
+							"        pm.expect(show.archive_lahmastore_base_url).to.be.an(\"string\")\r",
+							"        if (show.archive_mixcloud_base_url != null) {\r",
+							"            pm.expect(show.archive_mixcloud_base_url).to.be.an(\"string\")\r",
+							"        }\r",
+							"        pm.expect(show.cover_image_url).to.be.an(\"string\")\r",
+							"        pm.expect(show.id).to.be.an(\"number\")\r",
+							"    })\r",
+							"})"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "GET",
+				"header": [
+					{
+						"key": "Authentication-Token",
+						"value": "{{api_token}}",
+						"type": "text"
+					}
+				],
+				"url": {
+					"raw": "{{url}}/show/list",
+					"host": [
+						"{{url}}"
+					],
+					"path": [
+						"show",
+						"list"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Get Shows without Items (list_shows_without_items())",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"Status code is 200\", function () {\r",
+							"    pm.response.to.have.status(200)\r",
+							"})\r",
+							"\r",
+							"pm.test(\"Content-Type is text/html\", function() {\r",
+							"    pm.response.to.be.header(\"Content-Type\", \"text/html; charset=utf-8\")\r",
+							"})\r",
+							"\r",
+							"const jsonData = JSON.parse(responseBody)\r",
+							"pm.test(\"ResponseBody fields are correct!\", function() {\r",
+							"    pm.expect(jsonData).to.be.an(\"array\")\r",
+							"    jsonData.forEach(function(show) {\r",
+							"        pm.expect(show).to.be.an(\"object\")\r",
+							"        pm.expect(show.users).to.be.an(\"array\")\r",
+							"        show.users.forEach(function(user) {\r",
+							"            pm.expect(user).to.be.an(\"object\")\r",
+							"            pm.expect(user.name).to.be.an(\"string\")\r",
+							"            pm.expect(user.email).to.be.an(\"string\")\r",
+							"            pm.expect(user.id).to.be.an(\"number\")\r",
+							"        })\r",
+							"        pm.expect(show.active).to.be.an(\"boolean\")\r",
+							"        pm.expect(show.archive_lahmastore).to.be.an(\"boolean\")\r",
+							"        pm.expect(show.archive_mixcloud).to.be.an(\"boolean\")\r",
+							"        pm.expect(show.name).to.be.an(\"string\")\r",
+							"        pm.expect(show.description).to.be.an(\"string\")\r",
+							"        pm.expect(show.language).to.be.an(\"string\")\r",
+							"        pm.expect(show.playlist_name).to.be.an(\"string\")\r",
+							"        pm.expect(show.archive_lahmastore_base_url).to.be.an(\"string\")\r",
+							"        if (show.archive_mixcloud_base_url != null) {\r",
+							"            pm.expect(show.archive_mixcloud_base_url).to.be.an(\"string\")\r",
+							"        }\r",
+							"        pm.expect(show.cover_image_url).to.be.an(\"string\")\r",
+							"        pm.expect(show.start).to.be.an(\"string\")\r",
+							"        pm.expect(show.end).to.be.an(\"string\")\r",
+							"        pm.expect(show.day).to.be.an(\"number\")\r",
+							"        pm.expect(show.frequency).to.be.an(\"number\")\r",
+							"        pm.expect(show.week).to.be.an(\"number\")\r",
+							"        pm.expect(show.id).to.be.an(\"number\")\r",
+							"    })\r",
+							"})"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "GET",
+				"header": [
+					{
+						"key": "Authentication-Token",
+						"value": "{{api_token}}",
+						"type": "text"
+					}
+				],
+				"url": {
+					"raw": "{{url}}/show/all_without_items",
+					"host": [
+						"{{url}}"
+					],
+					"path": [
+						"show",
+						"all_without_items"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Search Show (search_show())",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"Status code is 200\", function () {\r",
+							"    pm.response.to.have.status(200)\r",
+							"})\r",
+							"\r",
+							"pm.test(\"Content-Type is text/html\", function() {\r",
+							"    pm.response.to.be.header(\"Content-Type\", \"text/html; charset=utf-8\")\r",
+							"})\r",
+							"\r",
+							"const jsonData = JSON.parse(responseBody)\r",
+							"pm.test(\"ResponseBody fields are correct!\", function() {\r",
+							"    pm.expect(jsonData).to.be.an(\"array\")\r",
+							"    jsonData.forEach(function(show) {\r",
+							"        pm.expect(show).to.be.an(\"object\")\r",
+							"        pm.expect(show.users).to.be.an(\"array\")\r",
+							"        show.users.forEach(function(user) {\r",
+							"            pm.expect(user).to.be.an(\"object\")\r",
+							"            pm.expect(user.name).to.be.an(\"string\")\r",
+							"            pm.expect(user.email).to.be.an(\"string\")\r",
+							"            pm.expect(user.id).to.be.an(\"number\")\r",
+							"        })\r",
+							"        pm.expect(show.active).to.be.an(\"boolean\")\r",
+							"        pm.expect(show.archive_lahmastore).to.be.an(\"boolean\")\r",
+							"        pm.expect(show.archive_mixcloud).to.be.an(\"boolean\")\r",
+							"        pm.expect(show.name).to.be.an(\"string\")\r",
+							"        pm.expect(show.description).to.be.an(\"string\")\r",
+							"        pm.expect(show.language).to.be.an(\"string\")\r",
+							"        pm.expect(show.playlist_name).to.be.an(\"string\")\r",
+							"        pm.expect(show.archive_lahmastore_base_url).to.be.an(\"string\")\r",
+							"        if (show.archive_mixcloud_base_url != null) {\r",
+							"            pm.expect(show.archive_mixcloud_base_url).to.be.an(\"string\")\r",
+							"        }\r",
+							"        pm.expect(show.cover_image_url).to.be.an(\"string\")\r",
+							"        pm.expect(show.start).to.be.an(\"string\")\r",
+							"        pm.expect(show.end).to.be.an(\"string\")\r",
+							"        pm.expect(show.day).to.be.an(\"number\")\r",
+							"        pm.expect(show.frequency).to.be.an(\"number\")\r",
+							"        pm.expect(show.week).to.be.an(\"number\")\r",
+							"        pm.expect(show.id).to.be.an(\"number\")\r",
+							"    })\r",
+							"})"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "GET",
+				"header": [
+					{
+						"key": "Authentication-Token",
+						"value": "{{api_token}}",
+						"type": "text"
+					}
+				],
+				"url": {
+					"raw": "{{url}}/show/search?param=show&page=1&size=12",
+					"host": [
+						"{{url}}"
+					],
+					"path": [
+						"show",
+						"search"
+					],
+					"query": [
+						{
+							"key": "param",
+							"value": "show"
+						},
+						{
+							"key": "page",
+							"value": "1"
+						},
+						{
+							"key": "size",
+							"value": "12"
+						}
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Get Shows for Schedule (list_shows_for_schedule())",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"Status code is 200\", function () {\r",
+							"    pm.response.to.have.status(200)\r",
+							"})\r",
+							"\r",
+							"pm.test(\"Content-Type is text/html\", function() {\r",
+							"    pm.response.to.be.header(\"Content-Type\", \"text/html; charset=utf-8\")\r",
+							"})\r",
+							"\r",
+							"const jsonData = JSON.parse(responseBody)\r",
+							"pm.test(\"ResponseBody fields are correct!\", function() {\r",
+							"    pm.expect(jsonData).to.be.an(\"array\")\r",
+							"    jsonData.forEach(function(show) {\r",
+							"        pm.expect(show).to.be.an(\"object\")\r",
+							"        pm.expect(show.users).to.be.an(\"array\")\r",
+							"        show.users.forEach(function(user) {\r",
+							"            pm.expect(user).to.be.an(\"object\")\r",
+							"            pm.expect(user.name).to.be.an(\"string\")\r",
+							"            pm.expect(user.email).to.be.an(\"string\")\r",
+							"            pm.expect(user.id).to.be.an(\"number\")\r",
+							"        })\r",
+							"        pm.expect(show.active).to.be.an(\"boolean\")\r",
+							"        pm.expect(show.archive_lahmastore).to.be.an(\"boolean\")\r",
+							"        pm.expect(show.archive_mixcloud).to.be.an(\"boolean\")\r",
+							"        pm.expect(show.name).to.be.an(\"string\")\r",
+							"        pm.expect(show.description).to.be.an(\"string\")\r",
+							"        pm.expect(show.language).to.be.an(\"string\")\r",
+							"        pm.expect(show.playlist_name).to.be.an(\"string\")\r",
+							"        pm.expect(show.archive_lahmastore_base_url).to.be.an(\"string\")\r",
+							"        if (show.archive_mixcloud_base_url != null) {\r",
+							"            pm.expect(show.archive_mixcloud_base_url).to.be.an(\"string\")\r",
+							"        }\r",
+							"        pm.expect(show.cover_image_url).to.be.an(\"string\")\r",
+							"        pm.expect(show.start).to.be.an(\"string\")\r",
+							"        pm.expect(show.end).to.be.an(\"string\")\r",
+							"        pm.expect(show.day).to.be.an(\"number\")\r",
+							"        pm.expect(show.frequency).to.be.an(\"number\")\r",
+							"        pm.expect(show.week).to.be.an(\"number\")\r",
+							"        pm.expect(show.id).to.be.an(\"number\")\r",
+							"    })\r",
+							"})"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "GET",
+				"header": [
+					{
+						"key": "Authentication-Token",
+						"value": "{{api_token}}",
+						"type": "text"
+					}
+				],
+				"url": {
+					"raw": "{{url}}/show/schedule",
+					"host": [
+						"{{url}}"
+					],
+					"path": [
+						"show",
+						"schedule"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Get Shows for Schedule by Day (list_shows_for_schedule_by())",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"Status code is 200\", function () {\r",
+							"    pm.response.to.have.status(200)\r",
+							"})\r",
+							"\r",
+							"pm.test(\"Content-Type is text/html\", function() {\r",
+							"    pm.response.to.be.header(\"Content-Type\", \"text/html; charset=utf-8\")\r",
+							"})\r",
+							"/*\r",
+							"const jsonData = JSON.parse(responseBody)\r",
+							"pm.test(\"ResponseBody fields are correct!\", function() {\r",
+							"    if (pm.expect(jsonData).to.be.an(\"array\")) {\r",
+							"        jsonData.forEach(function(show) {\r",
+							"            pm.expect(show).to.be.an(\"object\")\r",
+							"            if (show.items != null) {\r",
+							"                const latestEpisode = show.items\r",
+							"                pm.expect(latestEpisode).to.be.an(\"object\")\r",
+							"                pm.expect(latestEpisode.archived).to.be.an(\"boolean\")\r",
+							"                pm.expect(latestEpisode.name).to.be.an(\"string\")\r",
+							"                pm.expect(latestEpisode.name_slug).to.be.an(\"string\")\r",
+							"                pm.expect(latestEpisode.description).to.be.an(\"string\")\r",
+							"                pm.expect(latestEpisode.play_date).to.be.an(\"string\")\r",
+							"                pm.expect(latestEpisode.image_url).to.be.an(\"string\")\r",
+							"                if (latestEpisode.play_file_name != null) {\r",
+							"                    pm.expect(latestEpisode.play_file_name).to.be.an(\"string\")\r",
+							"                }\r",
+							"                pm.expect(latestEpisode.id).to.be.an(\"number\")\r",
+							"                pm.expect(latestEpisode.number).to.be.an(\"number\")\r",
+							"                pm.expect(latestEpisode.download_count).to.be.an(\"number\")\r",
+							"            }\r",
+							"            pm.expect(show.active).to.be.an(\"boolean\")\r",
+							"            pm.expect(show.name).to.be.an(\"string\")\r",
+							"            pm.expect(show.description).to.be.an(\"string\")\r",
+							"            pm.expect(show.playlist_name).to.be.an(\"string\")\r",
+							"            pm.expect(show.archive_lahmastore_base_url).to.be.an(\"string\")\r",
+							"            if (show.archive_mixcloud_base_url != null) {\r",
+							"                pm.expect(show.archive_mixcloud_base_url).to.be.an(\"string\")\r",
+							"            }\r",
+							"            pm.expect(show.cover_image_url).to.be.an(\"string\")\r",
+							"            pm.expect(show.start).to.be.an(\"string\")\r",
+							"            pm.expect(show.end).to.be.an(\"string\")\r",
+							"            pm.expect(show.day).to.be.an(\"number\")\r",
+							"            pm.expect(show.frequency).to.be.an(\"number\")\r",
+							"            pm.expect(show.id).to.be.an(\"number\")\r",
+							"        })\r",
+							"    }\r",
+							"    else if (pm.expect(jsonData).to.be.an(\"object\")) {\r",
+							"        const show = jsonData\r",
+							"        if (show.items != null) {\r",
+							"            const latestEpisode = show.items\r",
+							"            pm.expect(latestEpisode).to.be.an(\"object\")\r",
+							"            pm.expect(latestEpisode.archived).to.be.an(\"boolean\")\r",
+							"            pm.expect(latestEpisode.name).to.be.an(\"string\")\r",
+							"            pm.expect(latestEpisode.name_slug).to.be.an(\"string\")\r",
+							"            pm.expect(latestEpisode.description).to.be.an(\"string\")\r",
+							"            pm.expect(latestEpisode.play_date).to.be.an(\"string\")\r",
+							"            pm.expect(latestEpisode.image_url).to.be.an(\"string\")\r",
+							"            if (latestEpisode.play_file_name != null) {\r",
+							"                pm.expect(latestEpisode.play_file_name).to.be.an(\"string\")\r",
+							"            }\r",
+							"            pm.expect(latestEpisode.id).to.be.an(\"number\")\r",
+							"            pm.expect(latestEpisode.number).to.be.an(\"number\")\r",
+							"            pm.expect(latestEpisode.download_count).to.be.an(\"number\")\r",
+							"        }\r",
+							"        pm.expect(show.active).to.be.an(\"boolean\")\r",
+							"        pm.expect(show.name).to.be.an(\"string\")\r",
+							"        pm.expect(show.description).to.be.an(\"string\")\r",
+							"        pm.expect(show.playlist_name).to.be.an(\"string\")\r",
+							"        pm.expect(show.archive_lahmastore_base_url).to.be.an(\"string\")\r",
+							"        if (show.archive_mixcloud_base_url != null) {\r",
+							"            pm.expect(show.archive_mixcloud_base_url).to.be.an(\"string\")\r",
+							"        }\r",
+							"        pm.expect(show.cover_image_url).to.be.an(\"string\")\r",
+							"        pm.expect(show.start).to.be.an(\"string\")\r",
+							"        pm.expect(show.end).to.be.an(\"string\")\r",
+							"        pm.expect(show.day).to.be.an(\"number\")\r",
+							"        pm.expect(show.frequency).to.be.an(\"number\")\r",
+							"        pm.expect(show.id).to.be.an(\"number\")\r",
+							"    }\r",
+							"    else {\r",
+							"        pm.expect(jsonData).to.be.equal(\"[]\")\r",
+							"    }\r",
+							"})\r",
+							"*/"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "GET",
+				"header": [
+					{
+						"key": "Authentication-Token",
+						"value": "{{api_token}}",
+						"type": "text"
+					}
+				],
+				"url": {
+					"raw": "{{url}}/show/schedule_by?day=1",
+					"host": [
+						"{{url}}"
+					],
+					"path": [
+						"show",
+						"schedule_by"
+					],
+					"query": [
+						{
+							"key": "day",
+							"value": "1"
+						}
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Get Show for Show Subpage (view_show_page(show_slug))",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"Status code is 200\", function () {\r",
+							"    pm.response.to.have.status(200)\r",
+							"})\r",
+							"\r",
+							"pm.test(\"Content-Type is application/json\", function() {\r",
+							"    pm.response.to.be.header(\"Content-Type\", \"application/json\")\r",
+							"})\r",
+							"\r",
+							"const jsonData = JSON.parse(responseBody)\r",
+							"pm.test(\"ResponseBody is OK!\", function() {\r",
+							"    pm.expect(jsonData).to.be.an(\"object\")\r",
+							"    pm.expect(jsonData.items).to.be.an(\"array\")\r",
+							"    jsonData.items.forEach(function(item) {\r",
+							"        pm.expect(item).to.be.an(\"object\")\r",
+							"        pm.expect(item.archived).to.be.an(\"boolean\")\r",
+							"        pm.expect(item.name).to.be.an(\"string\")\r",
+							"        pm.expect(item.name_slug).to.be.an(\"string\")\r",
+							"        pm.expect(item.description).to.be.an(\"string\")\r",
+							"        pm.expect(item.play_date).to.be.an(\"string\")\r",
+							"        pm.expect(item.image_url).to.be.an(\"string\")\r",
+							"        if (item.play_file_name != null) {\r",
+							"            pm.expect(item.play_file_name).to.be.an(\"string\")\r",
+							"        }\r",
+							"        pm.expect(item.id).to.be.an(\"number\")\r",
+							"        pm.expect(item.number).to.be.an(\"number\")\r",
+							"        pm.expect(item.download_count).to.be.an(\"number\")\r",
+							"    })\r",
+							"    pm.expect(jsonData.active).to.be.an(\"boolean\")\r",
+							"    pm.expect(jsonData.name).to.be.an(\"string\")\r",
+							"    pm.expect(jsonData.description).to.be.an(\"string\")\r",
+							"    pm.expect(jsonData.language).to.be.an(\"string\")\r",
+							"    pm.expect(jsonData.playlist_name).to.be.an(\"string\")\r",
+							"    pm.expect(jsonData.archive_lahmastore_base_url).to.be.an(\"string\")\r",
+							"    if (jsonData.archive_mixcloud_base_url != null) {\r",
+							"        pm.expect(jsonData.archive_mixcloud_base_url).to.be.an(\"string\")\r",
+							"    }\r",
+							"    pm.expect(jsonData.cover_image_url).to.be.an(\"string\")\r",
+							"    pm.expect(jsonData.start).to.be.an(\"string\")\r",
+							"    pm.expect(jsonData.end).to.be.an(\"string\")\r",
+							"    pm.expect(jsonData.day).to.be.an(\"number\")\r",
+							"    pm.expect(jsonData.frequency).to.be.an(\"number\")\r",
+							"    pm.expect(jsonData.id).to.be.an(\"number\")\r",
+							"})\r",
+							"\r",
+							""
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "GET",
+				"header": [
+					{
+						"key": "Authentication-Token",
+						"value": "{{api_token}}",
+						"type": "text"
+					}
+				],
+				"url": {
+					"raw": "{{url}}/show/:show_slug/page",
+					"host": [
+						"{{url}}"
+					],
+					"path": [
+						"show",
+						":show_slug",
+						"page"
+					],
+					"variable": [
+						{
+							"key": "show_slug",
+							"value": "{{new_show_slug}}"
+						}
+					]
+				}
+			},
+			"response": []
+		}
+	]
+}

--- a/test/postman/robustness_test.postman_collection.json
+++ b/test/postman/robustness_test.postman_collection.json
@@ -197,7 +197,7 @@
 					"variable": [
 						{
 							"key": "id",
-							"value": "{{new_show_id}}"
+							"value": "1"
 						}
 					]
 				}

--- a/test/postman/robustness_test.postman_collection.json
+++ b/test/postman/robustness_test.postman_collection.json
@@ -205,7 +205,7 @@
 			"response": []
 		},
 		{
-			"name": "Get Items (0, list_items())",
+			"name": "Get Items (4, list_items())",
 			"event": [
 				{
 					"listen": "test",
@@ -295,6 +295,273 @@
 			"response": []
 		},
 		{
+			"name": "View Item (1, view_item(id))",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"Status code is 200\", function () {\r",
+							"    pm.response.to.have.status(200)\r",
+							"})\r",
+							"\r",
+							"pm.test(\"Content-Type is application/json\", function() {\r",
+							"    pm.response.to.be.header(\"Content-Type\", \"application/json\")\r",
+							"})\r",
+							"\r",
+							"pm.test(\"API responds within 5 sec (\" + pm.response.responseTime + \" msec)\", () => {\r",
+							"    const expectedTimeInMilliseconds = 5000;\r",
+							"    pm.expect(pm.response.responseTime).to.be.lessThan(\r",
+							"        expectedTimeInMilliseconds + 1,\r",
+							"        `Response came in ${pm.response.responseTime} ms`);\r",
+							"});\r",
+							"\r",
+							"const item = JSON.parse(responseBody)\r",
+							"pm.test(\"ResponseBody fields are correct!\", function() {\r",
+							"    pm.expect(item).to.be.an(\"object\")\r",
+							"    pm.expect(item.shows).to.be.an(\"array\")\r",
+							"    item.shows.forEach(function(show) {\r",
+							"        pm.expect(show).to.be.an(\"object\")\r",
+							"        pm.expect(show.name).to.be.an(\"string\")\r",
+							"        pm.expect(show.archive_lahmastore_base_url).to.be.an(\"string\")\r",
+							"        pm.expect(show.id).to.be.an(\"number\")\r",
+							"    })\r",
+							"    pm.expect(item.live).to.be.an(\"boolean\")\r",
+							"    pm.expect(item.broadcast).to.be.an(\"boolean\")\r",
+							"    if (item.airing != null) {\r",
+							"        pm.expect(item.airing).to.be.an(\"boolean\")\r",
+							"    }\r",
+							"    pm.expect(item.archived).to.be.an(\"boolean\")\r",
+							"    pm.expect(item.archive_lahmastore).to.be.an(\"boolean\")\r",
+							"    pm.expect(item.archive_mixcloud).to.be.an(\"boolean\")\r",
+							"    pm.expect(item.name).to.be.an(\"string\")\r",
+							"    pm.expect(item.name_slug).to.be.an(\"string\")\r",
+							"    pm.expect(item.description).to.be.an(\"string\")\r",
+							"    pm.expect(item.language).to.be.an(\"string\")\r",
+							"    pm.expect(item.play_date).to.be.an(\"string\")\r",
+							"    pm.expect(item.archive_lahmastore_canonical_url).to.be.an(\"string\")\r",
+							"    pm.expect(item.archive_mixcloud_canonical_url).to.be.an(\"string\")\r",
+							"    pm.expect(item.image_url).to.be.an(\"string\")\r",
+							"    if (item.play_file_name != null) {\r",
+							"        pm.expect(item.play_file_name).to.be.an(\"string\")\r",
+							"    }\r",
+							"    pm.expect(item.uploader).to.be.an(\"string\")\r",
+							"    pm.expect(item.id).to.be.an(\"number\")\r",
+							"    pm.expect(item.number).to.be.an(\"number\")\r",
+							"    pm.expect(item.download_count).to.be.an(\"number\")\r",
+							"})"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "GET",
+				"header": [
+					{
+						"key": "Authentication-Token",
+						"value": "{{api_token}}",
+						"type": "text"
+					}
+				],
+				"url": {
+					"raw": "{{url}}/item/:id",
+					"host": [
+						"{{url}}"
+					],
+					"path": [
+						"item",
+						":id"
+					],
+					"variable": [
+						{
+							"key": "id",
+							"value": "1"
+						}
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "View Item (2, view_item(id))",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"Status code is 200\", function () {\r",
+							"    pm.response.to.have.status(200)\r",
+							"})\r",
+							"\r",
+							"pm.test(\"Content-Type is application/json\", function() {\r",
+							"    pm.response.to.be.header(\"Content-Type\", \"application/json\")\r",
+							"})\r",
+							"\r",
+							"pm.test(\"API responds within 5 sec (\" + pm.response.responseTime + \" msec)\", () => {\r",
+							"    const expectedTimeInMilliseconds = 5000;\r",
+							"    pm.expect(pm.response.responseTime).to.be.lessThan(\r",
+							"        expectedTimeInMilliseconds + 1,\r",
+							"        `Response came in ${pm.response.responseTime} ms`);\r",
+							"});\r",
+							"\r",
+							"const item = JSON.parse(responseBody)\r",
+							"pm.test(\"ResponseBody fields are correct!\", function() {\r",
+							"    pm.expect(item).to.be.an(\"object\")\r",
+							"    pm.expect(item.shows).to.be.an(\"array\")\r",
+							"    item.shows.forEach(function(show) {\r",
+							"        pm.expect(show).to.be.an(\"object\")\r",
+							"        pm.expect(show.name).to.be.an(\"string\")\r",
+							"        pm.expect(show.archive_lahmastore_base_url).to.be.an(\"string\")\r",
+							"        pm.expect(show.id).to.be.an(\"number\")\r",
+							"    })\r",
+							"    pm.expect(item.live).to.be.an(\"boolean\")\r",
+							"    pm.expect(item.broadcast).to.be.an(\"boolean\")\r",
+							"    if (item.airing != null) {\r",
+							"        pm.expect(item.airing).to.be.an(\"boolean\")\r",
+							"    }\r",
+							"    pm.expect(item.archived).to.be.an(\"boolean\")\r",
+							"    pm.expect(item.archive_lahmastore).to.be.an(\"boolean\")\r",
+							"    pm.expect(item.archive_mixcloud).to.be.an(\"boolean\")\r",
+							"    pm.expect(item.name).to.be.an(\"string\")\r",
+							"    pm.expect(item.name_slug).to.be.an(\"string\")\r",
+							"    pm.expect(item.description).to.be.an(\"string\")\r",
+							"    pm.expect(item.language).to.be.an(\"string\")\r",
+							"    pm.expect(item.play_date).to.be.an(\"string\")\r",
+							"    pm.expect(item.archive_lahmastore_canonical_url).to.be.an(\"string\")\r",
+							"    pm.expect(item.archive_mixcloud_canonical_url).to.be.an(\"string\")\r",
+							"    pm.expect(item.image_url).to.be.an(\"string\")\r",
+							"    if (item.play_file_name != null) {\r",
+							"        pm.expect(item.play_file_name).to.be.an(\"string\")\r",
+							"    }\r",
+							"    pm.expect(item.uploader).to.be.an(\"string\")\r",
+							"    pm.expect(item.id).to.be.an(\"number\")\r",
+							"    pm.expect(item.number).to.be.an(\"number\")\r",
+							"    pm.expect(item.download_count).to.be.an(\"number\")\r",
+							"})"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "GET",
+				"header": [
+					{
+						"key": "Authentication-Token",
+						"value": "{{api_token}}",
+						"type": "text"
+					}
+				],
+				"url": {
+					"raw": "{{url}}/item/:id",
+					"host": [
+						"{{url}}"
+					],
+					"path": [
+						"item",
+						":id"
+					],
+					"variable": [
+						{
+							"key": "id",
+							"value": "2"
+						}
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "View Item (3, view_item(id))",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"Status code is 200\", function () {\r",
+							"    pm.response.to.have.status(200)\r",
+							"})\r",
+							"\r",
+							"pm.test(\"Content-Type is application/json\", function() {\r",
+							"    pm.response.to.be.header(\"Content-Type\", \"application/json\")\r",
+							"})\r",
+							"\r",
+							"pm.test(\"API responds within 5 sec (\" + pm.response.responseTime + \" msec)\", () => {\r",
+							"    const expectedTimeInMilliseconds = 5000;\r",
+							"    pm.expect(pm.response.responseTime).to.be.lessThan(\r",
+							"        expectedTimeInMilliseconds + 1,\r",
+							"        `Response came in ${pm.response.responseTime} ms`);\r",
+							"});\r",
+							"\r",
+							"const item = JSON.parse(responseBody)\r",
+							"pm.test(\"ResponseBody fields are correct!\", function() {\r",
+							"    pm.expect(item).to.be.an(\"object\")\r",
+							"    pm.expect(item.shows).to.be.an(\"array\")\r",
+							"    item.shows.forEach(function(show) {\r",
+							"        pm.expect(show).to.be.an(\"object\")\r",
+							"        pm.expect(show.name).to.be.an(\"string\")\r",
+							"        pm.expect(show.archive_lahmastore_base_url).to.be.an(\"string\")\r",
+							"        pm.expect(show.id).to.be.an(\"number\")\r",
+							"    })\r",
+							"    pm.expect(item.live).to.be.an(\"boolean\")\r",
+							"    pm.expect(item.broadcast).to.be.an(\"boolean\")\r",
+							"    if (item.airing != null) {\r",
+							"        pm.expect(item.airing).to.be.an(\"boolean\")\r",
+							"    }\r",
+							"    pm.expect(item.archived).to.be.an(\"boolean\")\r",
+							"    pm.expect(item.archive_lahmastore).to.be.an(\"boolean\")\r",
+							"    pm.expect(item.archive_mixcloud).to.be.an(\"boolean\")\r",
+							"    pm.expect(item.name).to.be.an(\"string\")\r",
+							"    pm.expect(item.name_slug).to.be.an(\"string\")\r",
+							"    pm.expect(item.description).to.be.an(\"string\")\r",
+							"    pm.expect(item.language).to.be.an(\"string\")\r",
+							"    pm.expect(item.play_date).to.be.an(\"string\")\r",
+							"    pm.expect(item.archive_lahmastore_canonical_url).to.be.an(\"string\")\r",
+							"    pm.expect(item.archive_mixcloud_canonical_url).to.be.an(\"string\")\r",
+							"    pm.expect(item.image_url).to.be.an(\"string\")\r",
+							"    if (item.play_file_name != null) {\r",
+							"        pm.expect(item.play_file_name).to.be.an(\"string\")\r",
+							"    }\r",
+							"    pm.expect(item.uploader).to.be.an(\"string\")\r",
+							"    pm.expect(item.id).to.be.an(\"number\")\r",
+							"    pm.expect(item.number).to.be.an(\"number\")\r",
+							"    pm.expect(item.download_count).to.be.an(\"number\")\r",
+							"})"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "GET",
+				"header": [
+					{
+						"key": "Authentication-Token",
+						"value": "{{api_token}}",
+						"type": "text"
+					}
+				],
+				"url": {
+					"raw": "{{url}}/item/:id",
+					"host": [
+						"{{url}}"
+					],
+					"path": [
+						"item",
+						":id"
+					],
+					"variable": [
+						{
+							"key": "id",
+							"value": "3"
+						}
+					]
+				}
+			},
+			"response": []
+		},
+		{
 			"name": "View Item (4, view_item(id))",
 			"event": [
 				{
@@ -376,7 +643,7 @@
 					"variable": [
 						{
 							"key": "id",
-							"value": "{{new_item_id}}"
+							"value": "4"
 						}
 					]
 				}
@@ -557,84 +824,6 @@
 						{
 							"key": "size",
 							"value": "12"
-						}
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "View Item with Slug (view_episode_archive(show_slug, item_slug))",
-			"event": [
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"pm.test(\"Status code is 200\", function () {\r",
-							"    pm.response.to.have.status(200)\r",
-							"})\r",
-							"\r",
-							"pm.test(\"Content-Type is application/json\", function() {\r",
-							"    pm.response.to.be.header(\"Content-Type\", \"application/json\")\r",
-							"})\r",
-							"\r",
-							"const item = JSON.parse(responseBody)\r",
-							"pm.test(\"ResponseBody fields are correct!\", function() {\r",
-							"    pm.expect(item).to.be.an(\"object\")\r",
-							"    pm.expect(item.shows).to.be.an(\"array\")\r",
-							"    item.shows.forEach(function(show){\r",
-							"        pm.expect(show).to.be.an(\"object\")\r",
-							"        pm.expect(show.name).to.be.an(\"string\")\r",
-							"        pm.expect(show.archive_lahmastore_base_url).to.be.an(\"string\")\r",
-							"        pm.expect(show.id).to.be.an(\"number\")\r",
-							"    })\r",
-							"    pm.expect(item.archived).to.be.an(\"boolean\")\r",
-							"    pm.expect(item.name).to.be.an(\"string\")\r",
-							"    pm.expect(item.name_slug).to.be.an(\"string\")\r",
-							"    pm.expect(item.description).to.be.an(\"string\")\r",
-							"    pm.expect(item.language).to.be.an(\"string\")\r",
-							"    pm.expect(item.play_date).to.be.an(\"string\")\r",
-							"    pm.expect(item.image_url).to.be.an(\"string\")\r",
-							"    if (item.play_file_name != null) {\r",
-							"        pm.expect(item.play_file_name).to.be.an(\"string\")\r",
-							"    }\r",
-							"    pm.expect(item.id).to.be.an(\"number\")\r",
-							"    pm.expect(item.number).to.be.an(\"number\")\r",
-							"    pm.expect(item.download_count).to.be.an(\"number\")\r",
-							"})"
-						],
-						"type": "text/javascript"
-					}
-				}
-			],
-			"request": {
-				"method": "GET",
-				"header": [
-					{
-						"key": "Authentication-Token",
-						"value": "{{api_token}}",
-						"type": "text"
-					}
-				],
-				"url": {
-					"raw": "{{url}}/show/:show_slug/item/:item_slug",
-					"host": [
-						"{{url}}"
-					],
-					"path": [
-						"show",
-						":show_slug",
-						"item",
-						":item_slug"
-					],
-					"variable": [
-						{
-							"key": "show_slug",
-							"value": "{{new_show_slug}}"
-						},
-						{
-							"key": "item_slug",
-							"value": "example_item1"
 						}
 					]
 				}
@@ -1053,92 +1242,6 @@
 						{
 							"key": "day",
 							"value": "1"
-						}
-					]
-				}
-			},
-			"response": []
-		},
-		{
-			"name": "Get Show for Show Subpage (view_show_page(show_slug))",
-			"event": [
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"pm.test(\"Status code is 200\", function () {\r",
-							"    pm.response.to.have.status(200)\r",
-							"})\r",
-							"\r",
-							"pm.test(\"Content-Type is application/json\", function() {\r",
-							"    pm.response.to.be.header(\"Content-Type\", \"application/json\")\r",
-							"})\r",
-							"\r",
-							"const jsonData = JSON.parse(responseBody)\r",
-							"pm.test(\"ResponseBody is OK!\", function() {\r",
-							"    pm.expect(jsonData).to.be.an(\"object\")\r",
-							"    pm.expect(jsonData.items).to.be.an(\"array\")\r",
-							"    jsonData.items.forEach(function(item) {\r",
-							"        pm.expect(item).to.be.an(\"object\")\r",
-							"        pm.expect(item.archived).to.be.an(\"boolean\")\r",
-							"        pm.expect(item.name).to.be.an(\"string\")\r",
-							"        pm.expect(item.name_slug).to.be.an(\"string\")\r",
-							"        pm.expect(item.description).to.be.an(\"string\")\r",
-							"        pm.expect(item.play_date).to.be.an(\"string\")\r",
-							"        pm.expect(item.image_url).to.be.an(\"string\")\r",
-							"        if (item.play_file_name != null) {\r",
-							"            pm.expect(item.play_file_name).to.be.an(\"string\")\r",
-							"        }\r",
-							"        pm.expect(item.id).to.be.an(\"number\")\r",
-							"        pm.expect(item.number).to.be.an(\"number\")\r",
-							"        pm.expect(item.download_count).to.be.an(\"number\")\r",
-							"    })\r",
-							"    pm.expect(jsonData.active).to.be.an(\"boolean\")\r",
-							"    pm.expect(jsonData.name).to.be.an(\"string\")\r",
-							"    pm.expect(jsonData.description).to.be.an(\"string\")\r",
-							"    pm.expect(jsonData.language).to.be.an(\"string\")\r",
-							"    pm.expect(jsonData.playlist_name).to.be.an(\"string\")\r",
-							"    pm.expect(jsonData.archive_lahmastore_base_url).to.be.an(\"string\")\r",
-							"    if (jsonData.archive_mixcloud_base_url != null) {\r",
-							"        pm.expect(jsonData.archive_mixcloud_base_url).to.be.an(\"string\")\r",
-							"    }\r",
-							"    pm.expect(jsonData.cover_image_url).to.be.an(\"string\")\r",
-							"    pm.expect(jsonData.start).to.be.an(\"string\")\r",
-							"    pm.expect(jsonData.end).to.be.an(\"string\")\r",
-							"    pm.expect(jsonData.day).to.be.an(\"number\")\r",
-							"    pm.expect(jsonData.frequency).to.be.an(\"number\")\r",
-							"    pm.expect(jsonData.id).to.be.an(\"number\")\r",
-							"})\r",
-							"\r",
-							""
-						],
-						"type": "text/javascript"
-					}
-				}
-			],
-			"request": {
-				"method": "GET",
-				"header": [
-					{
-						"key": "Authentication-Token",
-						"value": "{{api_token}}",
-						"type": "text"
-					}
-				],
-				"url": {
-					"raw": "{{url}}/show/:show_slug/page",
-					"host": [
-						"{{url}}"
-					],
-					"path": [
-						"show",
-						":show_slug",
-						"page"
-					],
-					"variable": [
-						{
-							"key": "show_slug",
-							"value": "{{new_show_slug}}"
 						}
 					]
 				}

--- a/test/postman/test.postman_environment.json
+++ b/test/postman/test.postman_environment.json
@@ -1,5 +1,5 @@
 {
-	"id": "d58ea83c-8b34-4a5a-aeb6-b9dbb08ac1e7",
+	"id": "84328a22-6486-43b6-9782-067bde50d6ea",
 	"name": "test",
 	"values": [
 		{
@@ -28,12 +28,12 @@
 		},
 		{
 			"key": "api_token",
-			"value": "",
+			"value": "WyIxIiwiJDUkcm91bmRzPTUzNTAwMCQ1VUpkL2hVS0NCTGVBSDNzJENqVTlIWkNDVXdSMnZmWlhFVVFscnh3WGJZSlh1dW1oSWcwMDh4VTMuWjYiXQ.Y4TTUg.2M2j0_GN5A2NagzZz1j59_lmOc8",
 			"type": "default",
 			"enabled": true
 		}
 	],
 	"_postman_variable_scope": "environment",
-	"_postman_exported_at": "2022-08-15T21:44:23.572Z",
-	"_postman_exported_using": "Postman/9.28.2"
+	"_postman_exported_at": "2022-11-28T15:32:23.506Z",
+	"_postman_exported_using": "Postman/10.5.2"
 }


### PR DESCRIPTION
I opened this new branch because the [previous](https://github.com/lahmacunradio/arcsi/pull/157) got messed up during a rebase.

The currently used [flask-security](https://flask-security.readthedocs.io/en/3.0.0/) package is no longer supported (latest change is 2,5 years old), [flask-security-too](https://flask-security-too.readthedocs.io/en/stable/) is the maintained up-to-date version of it.

Previously we talked about @gammaw that introducing the authentication made the frontend page is a bit slower.
This new security package offers some performance boost with version [3.1.0](https://github.com/Flask-Middleware/flask-security/blob/master/CHANGES.rst#version-310) and [3.2.0](https://github.com/Flask-Middleware/flask-security/blob/master/CHANGES.rst#version-320), for these uplifts we need a [modification](https://github.com/lahmacunradio/arcsi/pull/157/files/db80fc450235b0191d312f721a6aa68717fdfd73#diff-b221de923024f3e630e3d372fae43d57a72164cbe70f71b0dd9df23b36606983) which looks like a DB change [but it's not that](https://github.com/lahmacunradio/arcsi/pull/157/files/db80fc450235b0191d312f721a6aa68717fdfd73#diff-4d7c51b1efe9043e44439a949dfd92e5827321b34082903477fd04876edb7552). I checked the use of lazy parameter according to this [article](https://medium.com/@ns2586/sqlalchemys-relationship-and-lazy-parameter-4a553257d9ef) and it looks like we don't use it directly anywhere in the code, so no other changes needed.

We agreed that we should do some performance measurement before these upgrades:

- @gammaw suggested to do a profiling on the front end page to see exactly how much time each transaction takes
- I recommended to extend our CI with a robustness/benchmark test which can simulate a big load of incoming GET requests and measure the time it takes.

I extended the CI tests with the robustness/benchmark part,  you can see the results for flask-security-too version 3.0.2 [here](https://github.com/lahmacunradio/arcsi/actions/runs/3566629168/jobs/5993317000) and 3.2.0 [here](https://github.com/lahmacunradio/arcsi/actions/runs/3567620145/jobs/5995531210), it wasn't a big performance break-through :(