### PR TITLE
Remove temporary API workaround

### DIFF
--- a/arcsi/api/show.py
+++ b/arcsi/api/show.py
@@ -394,9 +394,6 @@ def view_show_page(show_slug):
         filter_params = comma_separated_params_to_list(filter_params[0])
     # TODO workaround for current frontend usage
     archived = 'archived' in filter_params
-    if archived == None:
-        if "https://lahmacun.hu" in request.environ.get('HTTP_ORIGIN'):
-            archived = True
     latest = 'latest' in filter_params
     show_query = Show.query.filter_by(archive_lahmastore_base_url=show_slug)
     show = show_query.first()


### PR DESCRIPTION
In order to be sync with the frontend we had to introduce a workaround in the previously merged PR (#172)

The changed API was already used by the frontend without any `filters` and the expected response was a filtered (without upcoming episodes) `items` field under the returned `show`.

Since the `archived` flag is added to the frontend code (in this PR https://github.com/lahmacunradio/frontend/pull/291) where it is needed, we can remove this workaround which added the `archived` flag in case the request was coming from the frontend

Connecting issues:
- https://github.com/lahmacunradio/frontend/issues/288
- https://github.com/lahmacunradio/frontend/issues/289