### PR TITLE
Using tmpreaper utility to maintain the tmp files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,9 +9,11 @@ WORKDIR /app
 RUN apt-get update \
     && apt-get install gcc g++ \
     libblas-dev libffi-dev liblapack-dev libopenblas-dev libpq-dev \
-    musl-dev postgresql -y \
+    musl-dev postgresql tmpreaper -y \
     && apt-get clean \
     && pip3 install -r requirements.txt
+
+ADD infra/tmpreaper.conf /etc/tmpreaper.conf
 
 ADD . /app
 

--- a/infra/tmpreaper.conf
+++ b/infra/tmpreaper.conf
@@ -41,7 +41,7 @@ SHOWWARNING=false
 #       extra options that are passed to tmpreaper, e.g. --all
 
 # uncomment and change the next line to overrule the /etc/default/rcS value
-TMPREAPER_TIME=21d
+TMPREAPER_TIME=7d
 
 TMPREAPER_PROTECT_EXTRA=''
 TMPREAPER_DIRS='/tmp/.'

--- a/infra/tmpreaper.conf
+++ b/infra/tmpreaper.conf
@@ -1,0 +1,49 @@
+# tmpreaper.conf
+# - local configuration for tmpreaper's daily run
+#
+# This is only used if /etc/cron.daily/tmpreaper was also updated,
+# i.e. there's a line ". /etc/tmpreaper.conf" in that file.
+# The shell code that used to be here (pre version 1.6.7) is now
+# in the cron.daily script.
+
+# Remove the next line if you understand the possible security implications of
+# having tmpreaper run automatically;
+# see /usr/share/doc/tmpreaper/README.security.gz
+
+SHOWWARNING=false
+
+# TMPREAPER_TIME
+#       is the max. age of files before they're removed.
+#       default:
+#       the TMPTIME value in /etc/default/rcS if it's there, else
+#       TMPREAPER_TIME=7d (for 7 days)
+#       I recommend setting the value in /etc/default/rcS, as
+#       that is used to clean out /tmp whenever the system is booted.
+#
+# TMPREAPER_PROTECT_EXTRA
+#       are extra patterns that you may want to protect.
+#       Example:
+#       TMPREAPER_PROTECT_EXTRA='/tmp/isdnctrl* /tmp/important*'
+#
+# TMPREAPER_DIRS
+#       are the directories to clean up.
+#       *never* supply / here! That will wipe most of your system!
+#       Example:
+#       TMPREAPER_DIRS='/tmp/. /var/tmp/.'
+#
+# TMPREAPER_DELAY
+#       defines the maximum (randomized) delay before starting processing.
+#       See the manpage entry for --delay. Default is 256.
+#       Example:
+#       TMPREAPER_DELAY='256'
+#
+# TMPREAPER_ADDITIONALOPTIONS
+#       extra options that are passed to tmpreaper, e.g. --all
+
+# uncomment and change the next line to overrule the /etc/default/rcS value
+TMPREAPER_TIME=21d
+
+TMPREAPER_PROTECT_EXTRA=''
+TMPREAPER_DIRS='/tmp/.'
+TMPREAPER_DELAY='256'
+TMPREAPER_ADDITIONALOPTIONS=''


### PR DESCRIPTION
**Why?**
We tend to write to tmp storage any file that is posted to arcsi which may fill the disk before we ever restart the system. Manually checking and deleting files is cumbersome and may result in errors (an open file is forcibly deleted)

**What has changed?**
A proven, old, stable utility for this situation has been added to our image -- please read [the manual for tmpreader](https://manpages.ubuntu.com/manpages/lunar/en/man8/tmpreaper.8.html) for details on how and what it can do

Also added a config file that specifies that files not touched within 21 days should be removed. The default directory where tmpreaper works is `/tmp/` so there is no need to set anything else. 

**How does it work?**
Upon install tmpreaper adds a job to `/etc/cron.daily` which uses the config file at `/etc/tmpreaper.conf` 

**Tests**
Ran this on sauce servers since I could not access prod instances. If merged please check it on prod as well however due to the minimal settings and single usecase I expect it will work all right. 