### PR TITLE
Revert nginx version update

### DIFF
--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:1.25.1
+FROM nginx:1.18-alpine
 
 # SSL through letsencrypt
 RUN apk add --no-cache certbot


### PR DESCRIPTION
In a [previous PR](https://github.com/lahmacunradio/arcsi/pull/176) I wrongly updated the version of nginx.
Although I tested the updated version locally on the prod server it had some issues and couldn't come up, I had to manually overwrite the version to the previous stable one.