### PR TITLE
Prepare Tags for frontend usage

### DIFF
--- a/arcsi/api/item.py
+++ b/arcsi/api/item.py
@@ -49,7 +49,7 @@ class ItemDetailsSchema(Schema):
     tags = fields.List(
         fields.Nested(
             "TagDetailsSchema",
-            only=("id", "display_name",),
+            only=("id", "display_name", "clean_name"),
         )
     )
 
@@ -139,7 +139,7 @@ def add_item():
             "name": item_metadata["show_name"]
         }
     ]
-    item_metadata["tags"] = [ { "display_name": tag_name } for tag_name in item_metadata["taglist"].split(",") ]
+    item_metadata["tags"] = [ { "display_name": tag_name.strip() } for tag_name in item_metadata["taglist"].split(",") ]
     item_metadata.pop("show_name", None)
     item_metadata.pop("taglist", None)
     
@@ -368,7 +368,7 @@ def edit_item(id):
     item_metadata["shows"] = [
         {"id": item_metadata["shows"], "name": item_metadata["show_name"]}
     ]
-    item_metadata["tags"] = [ { "display_name": tag_name } for tag_name in item_metadata["taglist"].split(",") ]
+    item_metadata["tags"] = [ { "display_name": tag_name.strip() } for tag_name in item_metadata["taglist"].split(",") ]
     item_metadata.pop("taglist", None)
     item_metadata.pop("show_name", None)
 

--- a/arcsi/api/show.py
+++ b/arcsi/api/show.py
@@ -63,7 +63,7 @@ class ShowDetailsSchema(Schema):
     tags = fields.List(
         fields.Nested(
             "TagDetailsSchema",
-            only=("id", "display_name",),
+            only=("id", "display_name", "clean_name"),
         )
     )
 
@@ -178,7 +178,7 @@ def add_show():
     ]
     show_metadata.pop("user_name", None)
     show_metadata.pop("user_email", None)
-    show_metadata["tags"] = [{"display_name": dis_name} for dis_name in show_metadata["taglist"].split(",")]
+    show_metadata["tags"] = [{"display_name": dis_name.strip()} for dis_name in show_metadata["taglist"].split(",")]
     show_metadata.pop("taglist", None)
 
     # validate payload
@@ -269,7 +269,7 @@ def edit_show(id):
     show_metadata.pop("user_name", None)
     show_metadata.pop("user_email", None)
 
-    show_metadata["tags"] = [{"display_name": dis_name} for dis_name in show_metadata["taglist"].split(",")]
+    show_metadata["tags"] = [{"display_name": dis_name.strip()} for dis_name in show_metadata["taglist"].split(",")]
     show_metadata.pop("taglist", None)
 
     # validate payload

--- a/arcsi/static/component.json
+++ b/arcsi/static/component.json
@@ -764,6 +764,42 @@
             "type": "file"
           }
         }
+      },
+      "TagResponseBody": {
+        "type": "object",
+        "properties": {
+            "id": {
+                "type": "integer",
+                "format": "int32"
+            },
+            "display_name": {
+                "type": "string"
+            },
+            "clean_name": {
+                "type": "string"
+            },
+            "icon": {
+                "type": "string"
+            },
+            "items": {
+                "type": "object",
+                "additionalProperties": {
+                    "$ref": "#/components/schemas/item"
+                }
+            },
+            "shows": {
+                "type": "object",
+                "additionalProperties": {
+                    "$ref": "#/components/schemas/show"
+                }
+            }
+        }      
+      },
+      "TagResponseBodies": {
+        "type": "object",
+        "additionalProperties": {
+            "$ref": "#/components/schemas/TagResponseBody"
+        }
       }
     }
   }

--- a/arcsi/static/doc.json
+++ b/arcsi/static/doc.json
@@ -27,6 +27,10 @@
       "description": "API for requesting and return Item details"
     },
     {
+      "name": "Tag Requests for frontend",
+      "description": "API for requesting and return Tag details"
+    },
+    {
       "name": "Show Requests for Arcsi",
       "description": "API for requesting and return Show details"
     },
@@ -277,95 +281,12 @@
         }
       }
     },
-    "/show/add_api": {
-      "post": {
-        "tags": [
-          "Show Requests for Arcsi"
-        ],
-        "summary": "Add Show to Arcsi (external use)",
-        "consumes": [
-          "multipart/form-data"
-        ],
-        "requestBody": {
-          "schema":{
-            "$ref": "component.json#/components/schemas/ShowRequestBody"
-          }
-        },
-        "produces": [
-          "application/json"
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "text/html": {
-                "schema": {
-                  "$ref": "component.json#/components/schemas/ShowResponseBody"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Invalid data sent to add show"
-          },
-          "503": {
-            "description": "Only accepts multipart/form-data for now, sorry"
-          }
-        }
-      }
-    },
     "/show/{id}/edit": {
       "post": {
         "tags": [
           "Show Requests for Arcsi"
         ],
         "summary": "Edit Show in Arcsi (internal use)",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "id",
-            "required": true,
-            "description": "Show.id",
-            "type": "string"
-          }
-        ],
-        "consumes": [
-          "multipart/form-data"
-        ],
-        "requestBody": {
-          "schema":{
-            "$ref": "component.json#/components/schemas/ShowRequestBody"
-          }
-        },
-        "produces": [
-          "application/json"
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "text/html": {
-                "schema": {
-                  "$ref": "component.json#/components/schemas/ShowResponseBody"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Show not found"
-          },
-          "500": {
-            "description": "Invalid data sent to edit show"
-          }
-        }
-      }
-    },
-    "/show/{id}/edit_api": {
-      "post": {
-        "tags": [
-          "Show Requests for Arcsi"
-        ],
-        "summary": "Edit Show in Arcsi (external use)",
         "parameters": [
           {
             "in": "path",
@@ -692,95 +613,12 @@
         }
       }
     },
-    "/item/add_api": {
-      "post": {
-        "tags": [
-          "Item Requests for Arcsi"
-        ],
-        "summary": "Add Item to Arcsi (external use)",
-        "consumes": [
-          "multipart/form-data"
-        ],
-        "requestBody": {
-          "schema":{
-            "$ref": "component.json#/components/schemas/ItemRequestBody"
-          }
-        },
-        "produces": [
-          "application/json"
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "text/html": {
-                "schema": {
-                  "$ref": "component.json#/components/schemas/ItemResponseBody"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Invalid data sent to add item"
-          },
-          "503": {
-            "description": "Only accepts multipart/form-data for now, sorry"
-          }
-        }
-      }
-    },
     "/item/{id}/edit": {
       "post": {
         "tags": [
           "Item Requests for Arcsi"
         ],
         "summary": "Edit Item in Arcsi (internal use)",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "id",
-            "required": true,
-            "description": "Item.id",
-            "type": "string"
-          }
-        ],
-        "consumes": [
-          "multipart/form-data"
-        ],
-        "requestBody": {
-          "schema":{
-            "$ref": "component.json#/components/schemas/ItemRequestBody"
-          }
-        },
-        "produces": [
-          "application/json"
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "text/html": {
-                "schema": {
-                  "$ref": "component.json#/components/schemas/ItemResponseBody"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Item not found"
-          },
-          "500": {
-            "description": "Invalid data sent to edit item"
-          }
-        }
-      }
-    },
-    "/item/{id}/edit_api": {
-      "post": {
-        "tags": [
-          "Item Requests for Arcsi"
-        ],
-        "summary": "Edit Item in Arcsi (external use)",
         "parameters": [
           {
             "in": "path",
@@ -1041,6 +879,64 @@
           },
           "404": {
             "description": "Failed. Item not found."
+          }
+        }
+      }
+    },
+    "/tag/all": {
+      "get": {
+        "tags": [
+          "Tag Requests for frontend"
+        ],
+        "summary": "Return all Tags",
+        "produces": [
+          "text/html"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/html": {
+                "schema": {
+                  "$ref": "component.json#/components/schemas/TagResponseBodies"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/tag/{tag_slug}": {
+      "get": {
+        "tags": [
+          "Tag Requests for frontend"
+        ],
+        "summary": "Return the given Tag",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "tag_slug",
+            "required": true,
+            "description": "Tag.clean_name",
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "component.json#/components/schemas/TagResponseBody"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Tag not found"
           }
         }
       }

--- a/test/postman/functional_test.postman_collection.json
+++ b/test/postman/functional_test.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "ad3b7596-289e-4122-83d1-4aebf04596a2",
+		"_postman_id": "6999efa4-6ab4-446e-b27e-5e7cddbc7c64",
 		"name": "CI test (functional)",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
@@ -587,7 +587,7 @@
 						},
 						{
 							"key": "taglist",
-							"value": "tag1, tag2, tag3",
+							"value": "tag1 , tag2 , tag3",
 							"type": "default"
 						},
 						{
@@ -664,6 +664,12 @@
 							"\r",
 							"pm.test(\"Tags number is 3\", function() {\r",
 							"    pm.expect(tags.length).to.equal(3)\r",
+							"})\r",
+							"\r",
+							"pm.test(\"Tags are stripped\", function() {\r",
+							"    pm.expect(tags[0].display_name).to.equal(\"tag1\")\r",
+							"    pm.expect(tags[1].display_name).to.equal(\"tag2\")\r",
+							"    pm.expect(tags[2].display_name).to.equal(\"tag3\")\r",
 							"})"
 						],
 						"type": "text/javascript"
@@ -2628,6 +2634,13 @@
 							"\r",
 							"pm.test(\"Tags number is 4\", function() {\r",
 							"    pm.expect(tags.length).to.equal(4)\r",
+							"})\r",
+							"\r",
+							"pm.test(\"Tags are stripped\", function() {\r",
+							"    pm.expect(tags[0].display_name).to.equal(\"tag1\")\r",
+							"    pm.expect(tags[1].display_name).to.equal(\"tag2\")\r",
+							"    pm.expect(tags[2].display_name).to.equal(\"tag3\")\r",
+							"    pm.expect(tags[3].display_name).to.equal(\"\")\r",
 							"})"
 						],
 						"type": "text/javascript"
@@ -3154,6 +3167,14 @@
 							"\r",
 							"pm.test(\"Tags number is 5\", function() {\r",
 							"    pm.expect(tags.length).to.equal(5)\r",
+							"})\r",
+							"\r",
+							"pm.test(\"Tags are stripped\", function() {\r",
+							"    pm.expect(tags[0].display_name).to.equal(\"tag1\")\r",
+							"    pm.expect(tags[1].display_name).to.equal(\"tag2\")\r",
+							"    pm.expect(tags[2].display_name).to.equal(\"tag3\")\r",
+							"    pm.expect(tags[3].display_name).to.equal(\"\")\r",
+							"    pm.expect(tags[4].display_name).to.equal(\"tag4\")\r",
 							"})"
 						],
 						"type": "text/javascript"


### PR DESCRIPTION
The goal of this PR is to extend the schemas connected to the newly introduced Tags and make them ready for the frontend usage.

Besides the schema extensions, I fixed a little glitch which caused unnecessary whitespaces, updated the Postman tests and Swagger docs.