### PR TITLE
Refactor Archon (Arcsi UI) endpoints

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         postgres-version: [12]
         python-version: [3.8]
-        node-version: [16]
+        node-version: [20]
 
     services:
       postgres:

--- a/arcsi/api/item.py
+++ b/arcsi/api/item.py
@@ -328,7 +328,7 @@ def listen_play_file(id):
 
 # Not used anywhere
 @arcsi.route("/archon/item/<int:id>/download", methods=["GET"])
-@auth_token_required
+@roles_accepted("admin", "host")
 def archon_download_play_file(id):
     do = DoArchive()
     item_query = Item.query.filter_by(id=id)

--- a/arcsi/api/item.py
+++ b/arcsi/api/item.py
@@ -2,7 +2,7 @@ from datetime import datetime, timedelta
 
 from flask import jsonify, make_response, request, redirect
 from flask import current_app as app
-from flask_security import auth_token_required, roles_required
+from flask_security import auth_token_required, roles_required, roles_accepted
 from marshmallow import fields, post_load, Schema
 from sqlalchemy import func
 
@@ -78,7 +78,7 @@ headers = {"Content-Type": "application/json"}
 @roles_required("admin")
 def archon_list_items():
     items = Item.query.all()
-    return archon_items_schema.dumps(items)
+    return archon_items_schema.dump(items)
 
 
 @arcsi.route("/item/latest", methods=["GET"])
@@ -97,13 +97,13 @@ def frontend_list_items_latest():
                 item.shows[0].archive_lahmastore_base_url, item.image_url
             )
         item.name_slug=normalise(item.name)
-    return items_archive_schema.dumps(items.items)
+    return items_archive_schema.dump(items.items)
 
 
 # As a legacy it's still used by the frontend in a fallback mechanism,
 # It should be replaced with the /show/<string:show_slug>/item/<string:item_slug>
 @arcsi.route("/item/<int:id>", methods=["GET"])
-@auth_token_required
+@roles_accepted("admin", "host")
 def archon_view_item(id):
     item_query = Item.query.filter_by(id=id)
     item = item_query.first_or_404()
@@ -316,7 +316,7 @@ def archon_add_item():
 
 # It's still used by the application for sure, and maybe by the frontend (?)
 @arcsi.route("/item/<int:id>/listen", methods=["GET"])
-@auth_token_required
+@roles_accepted("admin", "host")
 def listen_play_file(id):
     do = DoArchive()
     item_query = Item.query.filter_by(id=id)

--- a/arcsi/api/item.py
+++ b/arcsi/api/item.py
@@ -103,7 +103,7 @@ def frontend_list_items_latest():
 # As a legacy it's still used by the frontend in a fallback mechanism,
 # It should be replaced with the /show/<string:show_slug>/item/<string:item_slug>
 @arcsi.route("/item/<int:id>", methods=["GET"])
-@roles_accepted("admin", "host")
+@roles_accepted("admin", "host", "guest")
 def archon_view_item(id):
     item_query = Item.query.filter_by(id=id)
     item = item_query.first_or_404()

--- a/arcsi/api/show.py
+++ b/arcsi/api/show.py
@@ -347,7 +347,7 @@ def archon_edit_show(id):
 
 
 @arcsi.route("/archon/show/<int:id>", methods=["GET"])
-@auth_token_required
+@roles_accepted("admin", "host")
 def archon_view_show(id):
     do = DoArchive()
     show_query = Show.query.filter_by(id=id)

--- a/arcsi/api/show.py
+++ b/arcsi/api/show.py
@@ -3,7 +3,7 @@ import json
 from datetime import datetime, timedelta
 from flask import jsonify, make_response, request
 from flask import current_app as app
-from flask_security import auth_token_required, roles_required
+from flask_security import auth_token_required, roles_required, roles_accepted
 from marshmallow import fields, post_load, Schema
 from sqlalchemy import func
 
@@ -97,20 +97,20 @@ headers = {"Content-Type": "application/json"}
 @arcsi.route("/show/all", methods=["GET"])
 @auth_token_required
 def list_shows():
-    return shows_schema.dumps(get_shows())
+    return shows_schema.dump(get_shows())
 
 
 @arcsi.route("/show/all_without_items", methods=["GET"])
-@auth_token_required
+@roles_accepted("admin", "host")
 def frontend_list_shows_without_items():
-    return shows_schedule_schema.dumps(get_shows())
+    return shows_schedule_schema.dump(get_shows())
 
 
 @arcsi.route("/archon/show/all", methods=["GET"])
-@roles_required("admin")
+@roles_accepted("admin", "host")
 def archon_list_shows():
     shows = Show.query.all()
-    return archon_shows_schema.dumps(shows)   
+    return archon_shows_schema.dump(shows)   
 
 
 @arcsi.route("/show/schedule", methods=["GET"])
@@ -123,7 +123,7 @@ def frontend_list_shows_for_schedule():
             show.cover_image_url = do.download(
                 show.archive_lahmastore_base_url, show.cover_image_url
             )
-    return shows_schedule_schema.dumps(shows)    
+    return shows_schedule_schema.dump(shows)    
 
 
 @arcsi.route("/show/schedule_by", methods=["GET"])
@@ -156,14 +156,14 @@ def frontend_list_shows_for_schedule_by():
             # if there is no archived show return empty array
             if (latest_item_found == False):
                 show_json["items"] = []
-    return json.dumps(shows_json)
+    return json.dump(shows_json)
 
 
 # We are gonna use this on the new page as the show/all
 @arcsi.route("/show/list", methods=["GET"])
 @auth_token_required
 def frontend_list_shows_page():
-    return shows_archive_schema.dumps(get_shows())
+    return shows_archive_schema.dump(get_shows())
 
 
 # TODO /item/<uuid>/add route so that each upload has unique id to begin with
@@ -426,4 +426,4 @@ def frontend_search_show():
             show.cover_image_url = do.download(
                 show.archive_lahmastore_base_url, show.cover_image_url
             )
-    return shows_schedule_schema.dumps(shows.items)
+    return shows_schedule_schema.dump(shows.items)

--- a/arcsi/api/show.py
+++ b/arcsi/api/show.py
@@ -101,7 +101,7 @@ def list_shows():
 
 
 @arcsi.route("/show/all_without_items", methods=["GET"])
-@roles_accepted("admin", "host")
+@roles_accepted("admin", "host", "guest")
 def frontend_list_shows_without_items():
     return shows_schedule_schema.dump(get_shows())
 
@@ -156,7 +156,7 @@ def frontend_list_shows_for_schedule_by():
             # if there is no archived show return empty array
             if (latest_item_found == False):
                 show_json["items"] = []
-    return json.dump(shows_json)
+    return json.dumps(shows_json)
 
 
 # We are gonna use this on the new page as the show/all
@@ -347,7 +347,7 @@ def archon_edit_show(id):
 
 
 @arcsi.route("/archon/show/<int:id>", methods=["GET"])
-@roles_accepted("admin", "host")
+@roles_accepted("admin", "host", "guest")
 def archon_view_show(id):
     do = DoArchive()
     show_query = Show.query.filter_by(id=id)

--- a/arcsi/view/item.py
+++ b/arcsi/view/item.py
@@ -13,7 +13,7 @@ from arcsi.view import router
 @router.route("/item/all")
 @login_required
 def list_items():
-    items = archon_list_items().json()
+    items = archon_list_items()
     return render_template("item/list.html", items=items)
 
 
@@ -27,7 +27,7 @@ def add_item():
         return "add new show first"
 
     if current_user.has_role("admin"):
-        shows = frontend_list_shows_without_items().json()
+        shows = frontend_list_shows_without_items()
 
     shows_sorted = sorted(shows, key=lambda k: k['name'])
     return render_template("item/add.html", shows=shows_sorted)
@@ -36,27 +36,25 @@ def add_item():
 @router.route("/item/<id>", methods=["GET"])
 @login_required
 def view_item(id):
-    relpath = url_for("arcsi.archon_view_item", id=id)
     item = archon_view_item(id)
-    if item.status_code == 404:
+    if (hasattr(item, 'status_code') and item.status_code == 404):
         return "Episode not found"
-    item_json = item.json()
     #Check legacy None values if no image has been uploaded and change it to empty string so that the renderer doesn't throw error
-    if item_json["image_url"] == None:
-        item_json["image_url"] = ""
+    if item["image_url"] == None:
+        item["image_url"] = ""
     # use listen API to get the audio URL (HTTP response)
-    audiofile_URL = listen_play_file(id).text
+    audiofile_URL = listen_play_file(id)
+    
     # pass the audio URL to the template (text part of HTTP response)
-    return render_template("item/view.html", item=item_json, audiofile_URL=audiofile_URL)
+    return render_template("item/view.html", item=item, audiofile_URL=audiofile_URL)
 
 
 @router.route("/item/<id>/edit", methods=["GET"])
 @roles_accepted("admin", "host")
 def edit_item(id):
     item = archon_view_item(id)
-    if item.status_code == 404:
+    if (hasattr(item, 'status_code') and item.status_code == 404):
         return "Episode not found"
-    item_json = item.json()
-    shows = frontend_list_shows_without_items().json()
+    shows = frontend_list_shows_without_items()
     shows_sorted = sorted(shows, key=lambda k: k['name'])
-    return render_template("item/edit.html", item=item_json, shows=shows_sorted)
+    return render_template("item/edit.html", item=item, shows=shows_sorted)

--- a/arcsi/view/item.py
+++ b/arcsi/view/item.py
@@ -24,7 +24,7 @@ def add_item():
         return "add new show first"
 
     if current_user.has_role("admin"):
-        shows = frontend_list_shows_without_items().json()
+        shows = frontend_list_shows_without_items()
 
     shows_sorted = sorted(shows, key=lambda k: k['name'])
     return render_template("item/add.html", shows=shows_sorted)

--- a/arcsi/view/item.py
+++ b/arcsi/view/item.py
@@ -1,7 +1,4 @@
-import requests
-
-from flask import current_app as app
-from flask import render_template, url_for
+from flask import render_template
 from flask_login import current_user
 from flask_security import login_required, roles_accepted
 
@@ -27,7 +24,7 @@ def add_item():
         return "add new show first"
 
     if current_user.has_role("admin"):
-        shows = frontend_list_shows_without_items()
+        shows = frontend_list_shows_without_items().json()
 
     shows_sorted = sorted(shows, key=lambda k: k['name'])
     return render_template("item/add.html", shows=shows_sorted)

--- a/arcsi/view/show.py
+++ b/arcsi/view/show.py
@@ -1,4 +1,5 @@
 import requests
+import json
 
 from flask import current_app as app
 from flask import render_template, url_for
@@ -12,7 +13,7 @@ from arcsi.view import router
 @router.route("/show/all")
 @login_required
 def list_shows():
-    shows = archon_list_shows().json()
+    shows = archon_list_shows()
     return render_template("show/list.html", shows=shows)
 
 
@@ -26,16 +27,15 @@ def add_show():
 @login_required
 def view_show(id):
     show = archon_view_show(id)
-    if show.status_code == 404:
+    if (hasattr(show, 'status_code') and show.status_code == 404):
         return "Show not found"
-    show_json = show.json()
-    return render_template("show/view.html", show=show_json)
+    return render_template("show/view.html", show=show)
 
 
 @router.route("/show/<id>/edit", methods=["GET"])
 @roles_accepted("admin", "host")
 def edit_show(id):
     show = archon_view_show(id)
-    if show.status_code == 404:
+    if (hasattr(show, 'status_code') and show.status_code == 404):
         return "Show not found"
-    return render_template("show/edit.html", show=show.json())
+    return render_template("show/edit.html", show=show)

--- a/arcsi/view/show.py
+++ b/arcsi/view/show.py
@@ -1,9 +1,4 @@
-import requests
-import json
-
-from flask import current_app as app
-from flask import render_template, url_for
-from flask_login import current_user
+from flask import render_template
 from flask_security import login_required, roles_accepted
 
 from arcsi.api import archon_list_shows, archon_view_show

--- a/arcsi/view/show.py
+++ b/arcsi/view/show.py
@@ -5,14 +5,14 @@ from flask import render_template, url_for
 from flask_login import current_user
 from flask_security import login_required, roles_accepted
 
+from arcsi.api import archon_list_shows, archon_view_show
 from arcsi.view import router
 
 
 @router.route("/show/all")
 @login_required
 def list_shows():
-    result = requests.get(app.config["APP_BASE_URL"] + url_for("arcsi.archon_list_shows"), headers = {"Authentication-Token": current_user.get_auth_token()})
-    shows = result.json()
+    shows = archon_list_shows().json()
     return render_template("show/list.html", shows=shows)
 
 
@@ -25,8 +25,7 @@ def add_show():
 @router.route("/show/<id>", methods=["GET"])
 @login_required
 def view_show(id):
-    relpath = url_for("arcsi.archon_view_show", id=id)
-    show = requests.get(app.config["APP_BASE_URL"] + relpath, headers = {"Authentication-Token": current_user.get_auth_token()})
+    show = archon_view_show(id)
     if show.status_code == 404:
         return "Show not found"
     show_json = show.json()
@@ -36,8 +35,7 @@ def view_show(id):
 @router.route("/show/<id>/edit", methods=["GET"])
 @roles_accepted("admin", "host")
 def edit_show(id):
-    relpath = url_for("arcsi.archon_view_show", id=id)
-    show = requests.get(app.config["APP_BASE_URL"] + relpath, headers = {"Authentication-Token": current_user.get_auth_token()})
+    show = archon_view_show(id)
     if show.status_code == 404:
         return "Show not found"
     return render_template("show/edit.html", show=show.json())

--- a/arcsi/view/tag.py
+++ b/arcsi/view/tag.py
@@ -1,9 +1,4 @@
-import requests
-
-from flask import current_app as app
-from flask import render_template, request, url_for
-from flask_login import current_user
-from flask_security import roles_accepted, roles_required
+from flask import render_template
 
 from arcsi.api import list_tags
 from arcsi.view import router

--- a/arcsi/view/tag.py
+++ b/arcsi/view/tag.py
@@ -5,11 +5,11 @@ from flask import render_template, request, url_for
 from flask_login import current_user
 from flask_security import roles_accepted, roles_required
 
+from arcsi.api import list_tags
 from arcsi.view import router
 
 @router.route("/tag")
 @router.route("/tag/all")
 def list_tags():
-  tagged = requests.get(app.config["APP_BASE_URL"] + url_for("arcsi.list_tags"))
-  tags = tagged.json()
+  tags = list_tags().json()
   return render_template("tag/list.html", tags=tags)

--- a/arcsi/view/user.py
+++ b/arcsi/view/user.py
@@ -5,14 +5,14 @@ from flask import render_template, request, url_for
 from flask_login import current_user
 from flask_security import login_required, roles_required
 
+from arcsi.api import list_users
 from arcsi.view import router
 
 
 @router.route("/user/all")
 @roles_required('admin')
 def list_users():
-    result = requests.get(app.config["APP_BASE_URL"] + url_for("arcsi.list_users"))
-    users = result.json()
+    users = list_users().json()
     return render_template("user/list.html", users=users)
 
 

--- a/arcsi/view/user.py
+++ b/arcsi/view/user.py
@@ -1,7 +1,4 @@
-import requests
-
-from flask import current_app as app
-from flask import render_template, request, url_for
+from flask import render_template
 from flask_login import current_user
 from flask_security import login_required, roles_required
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
     links:
       - "db"
     build: .
-    image: arcsi:0.4.2
+    image: arcsi:0.4.3
     restart: always
     expose:
       - 5666

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
-service start cron
+service cron start
 python3 -m flask db upgrade
 gunicorn --worker-tmp-dir /dev/shm -t 30 -w 2 --worker-class=gthread --threads 2 -b 0.0.0.0:5666 --log-file /app/aguni.log --log-level info "arcsi:create_app('../config.py')"

--- a/test/postman/functional_test.postman_collection.json
+++ b/test/postman/functional_test.postman_collection.json
@@ -132,7 +132,7 @@
 							"})\r",
 							"\r",
 							"pm.test(\"Content-Type is text/html\", function() {\r",
-							"    pm.response.to.be.header(\"Content-Type\", \"text/html; charset=utf-8\")\r",
+							"    pm.response.to.be.header(\"Content-Type\", \"application/json\")\r",
 							"})\r",
 							"\r",
 							"pm.test(\"API responds within 5 sec (\" + pm.response.responseTime + \" msec)\", () => {\r",
@@ -194,7 +194,8 @@
 							"    pm.expect(shows.length).to.equal(0)\r",
 							"})"
 						],
-						"type": "text/javascript"
+						"type": "text/javascript",
+						"packages": {}
 					}
 				}
 			],
@@ -991,7 +992,7 @@
 							"})\r",
 							"\r",
 							"pm.test(\"Content-Type is text/html\", function() {\r",
-							"    pm.response.to.be.header(\"Content-Type\", \"text/html; charset=utf-8\")\r",
+							"    pm.response.to.be.header(\"Content-Type\", \"application/json\")\r",
 							"})\r",
 							"\r",
 							"pm.test(\"API responds within 5 sec (\" + pm.response.responseTime + \" msec)\", () => {\r",
@@ -1053,7 +1054,8 @@
 							"    pm.expect(shows.length).to.equal(1)\r",
 							"})"
 						],
-						"type": "text/javascript"
+						"type": "text/javascript",
+						"packages": {}
 					}
 				}
 			],
@@ -1091,7 +1093,7 @@
 							"})\r",
 							"\r",
 							"pm.test(\"Content-Type is text/html\", function() {\r",
-							"    pm.response.to.be.header(\"Content-Type\", \"text/html; charset=utf-8\")\r",
+							"    pm.response.to.be.header(\"Content-Type\", \"application/json\")\r",
 							"})\r",
 							"\r",
 							"pm.test(\"API responds within 5 sec (\" + pm.response.responseTime + \" msec)\", () => {\r",
@@ -1127,7 +1129,8 @@
 							"    pm.expect(shows.length).to.equal(1)\r",
 							"})"
 						],
-						"type": "text/javascript"
+						"type": "text/javascript",
+						"packages": {}
 					}
 				}
 			],
@@ -1321,7 +1324,7 @@
 							"})\r",
 							"\r",
 							"pm.test(\"Content-Type is text/html\", function() {\r",
-							"    pm.response.to.be.header(\"Content-Type\", \"text/html; charset=utf-8\")\r",
+							"    pm.response.to.be.header(\"Content-Type\", \"application/json\")\r",
 							"})\r",
 							"\r",
 							"pm.test(\"API responds within 5 sec (\" + pm.response.responseTime + \" msec)\", () => {\r",
@@ -1358,7 +1361,8 @@
 							"    pm.expect(items.length).to.equal(0)\r",
 							"})"
 						],
-						"type": "text/javascript"
+						"type": "text/javascript",
+						"packages": {}
 					}
 				}
 			],
@@ -2056,7 +2060,7 @@
 							"})\r",
 							"\r",
 							"pm.test(\"Content-Type is text/html\", function() {\r",
-							"    pm.response.to.be.header(\"Content-Type\", \"text/html; charset=utf-8\")\r",
+							"    pm.response.to.be.header(\"Content-Type\", \"application/json\")\r",
 							"})\r",
 							"\r",
 							"pm.test(\"API responds within 5 sec (\" + pm.response.responseTime + \" msec)\", () => {\r",
@@ -2093,7 +2097,8 @@
 							"    pm.expect(items.length).to.equal(1)\r",
 							"})"
 						],
-						"type": "text/javascript"
+						"type": "text/javascript",
+						"packages": {}
 					}
 				}
 			],
@@ -3087,7 +3092,7 @@
 							"})\r",
 							"\r",
 							"pm.test(\"Content-Type is text/html\", function() {\r",
-							"    pm.response.to.be.header(\"Content-Type\", \"text/html; charset=utf-8\")\r",
+							"    pm.response.to.be.header(\"Content-Type\", \"application/json\")\r",
 							"})\r",
 							"\r",
 							"pm.test(\"API responds within 5 sec (\" + pm.response.responseTime + \" msec)\", () => {\r",
@@ -3124,7 +3129,8 @@
 							"    pm.expect(items.length).to.equal(2)\r",
 							"})"
 						],
-						"type": "text/javascript"
+						"type": "text/javascript",
+						"packages": {}
 					}
 				}
 			],
@@ -3703,7 +3709,7 @@
 							"})\r",
 							"\r",
 							"pm.test(\"Content-Type is text/html\", function() {\r",
-							"    pm.response.to.be.header(\"Content-Type\", \"text/html; charset=utf-8\")\r",
+							"    pm.response.to.be.header(\"Content-Type\", \"application/json\")\r",
 							"})\r",
 							"\r",
 							"pm.test(\"API responds within 5 sec (\" + pm.response.responseTime + \" msec)\", () => {\r",
@@ -3740,7 +3746,8 @@
 							"    pm.expect(items.length).to.equal(3)\r",
 							"})"
 						],
-						"type": "text/javascript"
+						"type": "text/javascript",
+						"packages": {}
 					}
 				}
 			],
@@ -4126,7 +4133,7 @@
 							"})\r",
 							"\r",
 							"pm.test(\"Content-Type is text/html\", function() {\r",
-							"    pm.response.to.be.header(\"Content-Type\", \"text/html; charset=utf-8\")\r",
+							"    pm.response.to.be.header(\"Content-Type\", \"application/json\")\r",
 							"})\r",
 							"\r",
 							"pm.test(\"API responds within 5 sec (\" + pm.response.responseTime + \" msec)\", () => {\r",
@@ -4163,7 +4170,8 @@
 							"    pm.expect(items.length).to.equal(4)\r",
 							"})"
 						],
-						"type": "text/javascript"
+						"type": "text/javascript",
+						"packages": {}
 					}
 				}
 			],
@@ -4853,7 +4861,7 @@
 							"})\r",
 							"\r",
 							"pm.test(\"Content-Type is text/html\", function() {\r",
-							"    pm.response.to.be.header(\"Content-Type\", \"text/html; charset=utf-8\")\r",
+							"    pm.response.to.be.header(\"Content-Type\", \"application/json\")\r",
 							"})\r",
 							"\r",
 							"pm.test(\"API responds within 5 sec (\" + pm.response.responseTime + \" msec)\", () => {\r",
@@ -4890,7 +4898,8 @@
 							"    pm.expect(items.length).to.equal(4)\r",
 							"})"
 						],
-						"type": "text/javascript"
+						"type": "text/javascript",
+						"packages": {}
 					}
 				}
 			],
@@ -5512,7 +5521,7 @@
 							"})\r",
 							"\r",
 							"pm.test(\"Content-Type is text/html\", function() {\r",
-							"    pm.response.to.be.header(\"Content-Type\", \"text/html; charset=utf-8\")\r",
+							"    pm.response.to.be.header(\"Content-Type\", \"application/json\")\r",
 							"})\r",
 							"\r",
 							"pm.test(\"API responds within 5 sec (\" + pm.response.responseTime + \" msec)\", () => {\r",
@@ -5549,7 +5558,8 @@
 							"    pm.expect(items.length).to.equal(5)\r",
 							"})"
 						],
-						"type": "text/javascript"
+						"type": "text/javascript",
+						"packages": {}
 					}
 				}
 			],
@@ -5925,7 +5935,7 @@
 							"})\r",
 							"\r",
 							"pm.test(\"Content-Type is text/html\", function() {\r",
-							"    pm.response.to.be.header(\"Content-Type\", \"text/html; charset=utf-8\")\r",
+							"    pm.response.to.be.header(\"Content-Type\", \"application/json\")\r",
 							"})\r",
 							"\r",
 							"const jsonData = JSON.parse(responseBody)\r",
@@ -5946,7 +5956,8 @@
 							"    })\r",
 							"})"
 						],
-						"type": "text/javascript"
+						"type": "text/javascript",
+						"packages": {}
 					}
 				}
 			],
@@ -6019,7 +6030,8 @@
 							"    })\r",
 							"})"
 						],
-						"type": "text/javascript"
+						"type": "text/javascript",
+						"packages": {}
 					}
 				}
 			],
@@ -6057,7 +6069,7 @@
 							"})\r",
 							"\r",
 							"pm.test(\"Content-Type is text/html\", function() {\r",
-							"    pm.response.to.be.header(\"Content-Type\", \"text/html; charset=utf-8\")\r",
+							"    pm.response.to.be.header(\"Content-Type\", \"application/json\")\r",
 							"})\r",
 							"\r",
 							"const jsonData = JSON.parse(responseBody)\r",
@@ -6092,7 +6104,8 @@
 							"    })\r",
 							"})"
 						],
-						"type": "text/javascript"
+						"type": "text/javascript",
+						"packages": {}
 					}
 				}
 			],
@@ -6144,7 +6157,7 @@
 							"})\r",
 							"\r",
 							"pm.test(\"Content-Type is text/html\", function() {\r",
-							"    pm.response.to.be.header(\"Content-Type\", \"text/html; charset=utf-8\")\r",
+							"    pm.response.to.be.header(\"Content-Type\", \"application/json\")\r",
 							"})\r",
 							"\r",
 							"const jsonData = JSON.parse(responseBody)\r",
@@ -6179,7 +6192,8 @@
 							"    })\r",
 							"})"
 						],
-						"type": "text/javascript"
+						"type": "text/javascript",
+						"packages": {}
 					}
 				}
 			],

--- a/test/postman/functional_test.postman_collection.json
+++ b/test/postman/functional_test.postman_collection.json
@@ -5686,7 +5686,7 @@
 							"})\r",
 							"\r",
 							"pm.test(\"Content-Type is text/html\", function() {\r",
-							"    pm.response.to.be.header(\"Content-Type\", \"text/html; charset=utf-8\")\r",
+							"    pm.response.to.be.header(\"Content-Type\", \"application/json\")\r",
 							"})\r",
 							"\r",
 							"const jsonData = JSON.parse(responseBody)\r",
@@ -5717,7 +5717,8 @@
 							"    })\r",
 							"})"
 						],
-						"type": "text/javascript"
+						"type": "text/javascript",
+						"packages": {}
 					}
 				}
 			],
@@ -5995,7 +5996,7 @@
 							"})\r",
 							"\r",
 							"pm.test(\"Content-Type is text/html\", function() {\r",
-							"    pm.response.to.be.header(\"Content-Type\", \"text/html; charset=utf-8\")\r",
+							"    pm.response.to.be.header(\"Content-Type\", \"application/json\")\r",
 							"})\r",
 							"\r",
 							"const jsonData = JSON.parse(responseBody)\r",

--- a/test/postman/robustness_test.postman_collection.json
+++ b/test/postman/robustness_test.postman_collection.json
@@ -333,7 +333,7 @@
 							"})\r",
 							"\r",
 							"pm.test(\"Content-Type is text/html\", function() {\r",
-							"    pm.response.to.be.header(\"Content-Type\", \"text/html; charset=utf-8\")\r",
+							"    pm.response.to.be.header(\"Content-Type\", \"application/json\")\r",
 							"})\r",
 							"\r",
 							"pm.test(\"API responds within 5 sec (\" + pm.response.responseTime + \" msec)\", () => {\r",
@@ -370,7 +370,8 @@
 							"    pm.expect(items.length).to.equal(5)\r",
 							"})"
 						],
-						"type": "text/javascript"
+						"type": "text/javascript",
+						"packages": {}
 					}
 				}
 			],

--- a/test/postman/robustness_test.postman_collection.json
+++ b/test/postman/robustness_test.postman_collection.json
@@ -761,7 +761,7 @@
 							"})\r",
 							"\r",
 							"pm.test(\"Content-Type is text/html\", function() {\r",
-							"    pm.response.to.be.header(\"Content-Type\", \"text/html; charset=utf-8\")\r",
+							"    pm.response.to.be.header(\"Content-Type\", \"application/json\")\r",
 							"})\r",
 							"\r",
 							"const jsonData = JSON.parse(responseBody)\r",
@@ -792,7 +792,8 @@
 							"    })\r",
 							"})"
 						],
-						"type": "text/javascript"
+						"type": "text/javascript",
+						"packages": {}
 					}
 				}
 			],
@@ -992,7 +993,7 @@
 							"})\r",
 							"\r",
 							"pm.test(\"Content-Type is text/html\", function() {\r",
-							"    pm.response.to.be.header(\"Content-Type\", \"text/html; charset=utf-8\")\r",
+							"    pm.response.to.be.header(\"Content-Type\", \"application/json\")\r",
 							"})\r",
 							"\r",
 							"const jsonData = JSON.parse(responseBody)\r",
@@ -1027,7 +1028,8 @@
 							"    })\r",
 							"})"
 						],
-						"type": "text/javascript"
+						"type": "text/javascript",
+						"packages": {}
 					}
 				}
 			],

--- a/test/postman/robustness_test.postman_collection.json
+++ b/test/postman/robustness_test.postman_collection.json
@@ -132,7 +132,7 @@
 							"})\r",
 							"\r",
 							"pm.test(\"Content-Type is text/html\", function() {\r",
-							"    pm.response.to.be.header(\"Content-Type\", \"text/html; charset=utf-8\")\r",
+							"    pm.response.to.be.header(\"Content-Type\", \"application/json\")\r",
 							"})\r",
 							"\r",
 							"pm.test(\"API responds within 5 sec (\" + pm.response.responseTime + \" msec)\", () => {\r",
@@ -194,7 +194,8 @@
 							"    pm.expect(shows.length).to.equal(1)\r",
 							"})"
 						],
-						"type": "text/javascript"
+						"type": "text/javascript",
+						"packages": {}
 					}
 				}
 			],
@@ -931,7 +932,7 @@
 							"})\r",
 							"\r",
 							"pm.test(\"Content-Type is text/html\", function() {\r",
-							"    pm.response.to.be.header(\"Content-Type\", \"text/html; charset=utf-8\")\r",
+							"    pm.response.to.be.header(\"Content-Type\", \"application/json\")\r",
 							"})\r",
 							"\r",
 							"const jsonData = JSON.parse(responseBody)\r",
@@ -952,7 +953,8 @@
 							"    })\r",
 							"})"
 						],
-						"type": "text/javascript"
+						"type": "text/javascript",
+						"packages": {}
 					}
 				}
 			],
@@ -1063,7 +1065,7 @@
 							"})\r",
 							"\r",
 							"pm.test(\"Content-Type is text/html\", function() {\r",
-							"    pm.response.to.be.header(\"Content-Type\", \"text/html; charset=utf-8\")\r",
+							"    pm.response.to.be.header(\"Content-Type\", \"application/json\")\r",
 							"})\r",
 							"\r",
 							"const jsonData = JSON.parse(responseBody)\r",
@@ -1098,7 +1100,8 @@
 							"    })\r",
 							"})"
 						],
-						"type": "text/javascript"
+						"type": "text/javascript",
+						"packages": {}
 					}
 				}
 			],
@@ -1150,7 +1153,7 @@
 							"})\r",
 							"\r",
 							"pm.test(\"Content-Type is text/html\", function() {\r",
-							"    pm.response.to.be.header(\"Content-Type\", \"text/html; charset=utf-8\")\r",
+							"    pm.response.to.be.header(\"Content-Type\", \"application/json\")\r",
 							"})\r",
 							"\r",
 							"const jsonData = JSON.parse(responseBody)\r",
@@ -1185,7 +1188,8 @@
 							"    })\r",
 							"})"
 						],
-						"type": "text/javascript"
+						"type": "text/javascript",
+						"packages": {}
 					}
 				}
 			],


### PR DESCRIPTION
Massive performance boost for Archon (Arcsi UI) pages.
- I did a refactor for the `view`/`router` endpoints:
  - Previously we called the `api`/`arcsi` endpoints inside these endpoints, which as we saw put some additional, not properly handled load on the gunicorn workers
  - I refactored these endpoints to call the exact `api`/`arcsi` functions from the code instead of calling the exposed endpoints
  - These resulted a significantly faster response for Archon show and episode subpages, and a slightly faster response for the big, 'Shows archive' and 'Items archive' pages.
  - I also had to align the flask-security related decorators, for the directly used `api`/`arcsi` endpoints/functions

I had to align the CI tests as well.

Small fix in `entrypoint.sh` for the cron job to properly start when the app container is created, this was required for tmpreaper usage.

GitHub Actions recommended to upgrade the Node version from 16 to 20.

PR was tested locally and it is also deployed currently on the dev env.
It seems like there is no frontend compatibility issues either.