### PR TITLE
Archon RBAC, Welcome Show Hosts!

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,10 +38,10 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
     - name: Git checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4.2.2
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5.3.0
       with:
         python-version: ${{ matrix.python-version }}
         cache: 'pip'
@@ -51,7 +51,7 @@ jobs:
         pip install -r requirements.txt
 
     - name: Set up Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4.1.0
       with:
         node-version: ${{ matrix.node-version }}
 
@@ -93,7 +93,7 @@ jobs:
         newman run robustness_test.postman_collection.json -e test.postman_environment.json -n 50 -k
 
     - name: Upload logs
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4.3.3
       if: failure()
       with:
         path: aguni.log

--- a/arcsi/__init__.py
+++ b/arcsi/__init__.py
@@ -2,6 +2,7 @@ import logging
 import os
 
 from flask import Flask
+from flask_ckeditor import CKEditor
 from flask_security import Security, SQLAlchemySessionUserDatastore
 from flask_migrate import Migrate
 from flask_swagger_ui import get_swaggerui_blueprint
@@ -11,6 +12,7 @@ from arcsi.model import db, item, role, show, tag, user
 from arcsi.view.forms.register import ButtRegisterForm
 
 migrate = Migrate()
+ckeditor = CKEditor()
 
 
 def create_app(config_file):
@@ -39,6 +41,7 @@ def create_app(config_file):
     with app.app_context():
         db.init_app(app)
         migrate.init_app(app, db)
+        ckeditor.init_app(app)
 
         '''
         The application factory runs when `flask db upgrade` is called

--- a/arcsi/api/item.py
+++ b/arcsi/api/item.py
@@ -8,8 +8,9 @@ from sqlalchemy import func
 
 from uuid import uuid4
 
-from .utils import archive, broadcast_audio, normalise, save_file, show_item_duplications_number
 from . import arcsi
+from .utils import archive, broadcast_audio, normalise, save_file
+from .utils import get_items, show_item_duplications_number
 from arcsi.handler.upload import DoArchive
 from arcsi.model import db
 from arcsi.model.item import Item
@@ -77,8 +78,7 @@ headers = {"Content-Type": "application/json"}
 @arcsi.route("/archon/item/all", methods=["GET"])
 @roles_accepted("admin", "host")
 def archon_list_items():
-    items = Item.query.all()
-    return archon_items_schema.dump(items)
+    return archon_items_schema.dump(get_items())
 
 
 @arcsi.route("/item/latest", methods=["GET"])
@@ -103,7 +103,7 @@ def frontend_list_items_latest():
 # As a legacy it's still used by the frontend in a fallback mechanism,
 # It should be replaced with the /show/<string:show_slug>/item/<string:item_slug>
 @arcsi.route("/item/<int:id>", methods=["GET"])
-@auth_token_required
+@roles_accepted("admin", "host", "guest")
 def archon_view_item(id):
     item_query = Item.query.filter_by(id=id)
     item = item_query.first_or_404()

--- a/arcsi/api/item.py
+++ b/arcsi/api/item.py
@@ -103,7 +103,7 @@ def frontend_list_items_latest():
 # As a legacy it's still used by the frontend in a fallback mechanism,
 # It should be replaced with the /show/<string:show_slug>/item/<string:item_slug>
 @arcsi.route("/item/<int:id>", methods=["GET"])
-@roles_accepted("admin", "host", "guest")
+@auth_token_required
 def archon_view_item(id):
     item_query = Item.query.filter_by(id=id)
     item = item_query.first_or_404()
@@ -120,7 +120,7 @@ def archon_view_item(id):
 
 
 @arcsi.route("/archon/item/add", methods=["POST"])
-@roles_required("admin")
+@roles_accepted("admin", "host")
 def archon_add_item():
     no_error = True
     if request.is_json:
@@ -341,7 +341,7 @@ def archon_download_play_file(id):
 
 # TODO implement delete functionality
 @arcsi.route("/archon/item/<int:id>", methods=["DELETE"])
-@roles_required("admin")
+@roles_accepted("admin", "host")
 def archon_delete_item(id):
     item_query = Item.query.filter_by(id=id)
     item = item_query.first_or_404()
@@ -351,7 +351,7 @@ def archon_delete_item(id):
 
 
 @arcsi.route("/archon/item/<int:id>/edit", methods=["POST"])
-@roles_required("admin")
+@roles_accepted("admin", "host")
 def archon_edit_item(id):
     no_error = True
     image_file = None

--- a/arcsi/api/item.py
+++ b/arcsi/api/item.py
@@ -366,7 +366,10 @@ def archon_edit_item(id):
 
     # TODO if we could send JSON payloads w/ ajax then this prevalidation isn't needed
     item_metadata["shows"] = [
-        {"id": item_metadata["shows"], "name": item_metadata["show_name"]}
+        {
+            "id": item_metadata["shows"],
+            "name": item_metadata["show_name"]
+        }
     ]
     item_metadata["tags"] = [ { "display_name": tag_name.strip() } for tag_name in item_metadata["taglist"].split(",") ]
     item_metadata["tags"] = [dict(t) for t in {tuple(d.items()) for d in item_metadata["tags"]}]

--- a/arcsi/api/item.py
+++ b/arcsi/api/item.py
@@ -2,7 +2,7 @@ from datetime import datetime, timedelta
 
 from flask import jsonify, make_response, request, redirect
 from flask import current_app as app
-from flask_security import auth_token_required, roles_required, roles_accepted
+from flask_security import auth_token_required, roles_accepted
 from marshmallow import fields, post_load, Schema
 from sqlalchemy import func
 
@@ -75,7 +75,7 @@ headers = {"Content-Type": "application/json"}
 
 @arcsi.route("/item", methods=["GET"])
 @arcsi.route("/archon/item/all", methods=["GET"])
-@roles_required("admin")
+@roles_accepted("admin", "host")
 def archon_list_items():
     items = Item.query.all()
     return archon_items_schema.dump(items)

--- a/arcsi/api/show.py
+++ b/arcsi/api/show.py
@@ -7,7 +7,7 @@ from flask_security import auth_token_required, roles_required, roles_accepted
 from marshmallow import fields, post_load, Schema
 from sqlalchemy import func
 
-from .utils import archive, get_shows, save_file, slug, sort_for, normalise, comma_separated_params_to_list, filter_show_items
+from .utils import archive, get_shows_with_cover, save_file, slug, sort_for, normalise, comma_separated_params_to_list, filter_show_items
 from . import arcsi
 from arcsi.handler.upload import DoArchive
 from arcsi.model import db
@@ -98,13 +98,13 @@ headers = {"Content-Type": "application/json"}
 @arcsi.route("/show/all", methods=["GET"])
 @auth_token_required
 def list_shows():
-    return shows_schema.dump(get_shows())
+    return shows_schema.dump(get_shows_with_cover())
 
 
 @arcsi.route("/show/all_without_items", methods=["GET"])
 @auth_token_required
 def frontend_list_shows_without_items():
-    return shows_schedule_schema.dump(get_shows())
+    return shows_schedule_schema.dump(get_shows_with_cover())
 
 
 @arcsi.route("/archon/show/all", methods=["GET"])
@@ -164,7 +164,7 @@ def frontend_list_shows_for_schedule_by():
 @arcsi.route("/show/list", methods=["GET"])
 @auth_token_required
 def frontend_list_shows_page():
-    return shows_archive_schema.dump(get_shows())
+    return shows_archive_schema.dump(get_shows_with_cover())
 
 
 # TODO /item/<uuid>/add route so that each upload has unique id to begin with

--- a/arcsi/api/show.py
+++ b/arcsi/api/show.py
@@ -78,6 +78,7 @@ show_archive_schema = ShowDetailsSchema(only=("id", "active", "name", "descripti
                                                     "playlist_name", "archive_lahmastore_base_url", "external_url", "items", "tags"))
 show_partial_schema = ShowDetailsSchema(partial=True)
 shows_schema = ShowDetailsSchema(many=True)
+shows_minimal_schema = ShowDetailsSchema(many=True, only=("id", "name"))
 shows_schedule_schema = ShowDetailsSchema(many=True, exclude=("items", "contact_address"))
 shows_schedule_by_schema = ShowDetailsSchema(many=True, 
                                                     only=("id", "active", "name", "description", "cover_image_url", 

--- a/arcsi/api/show.py
+++ b/arcsi/api/show.py
@@ -181,11 +181,12 @@ def archon_add_show():
     # TODO see item.py same line
     show_metadata["users"] = [
         {
-            "id": show_metadata["users"],
+            "id": show_metadata["user_id"],
             "name": show_metadata["user_name"],
             "email": show_metadata["user_email"],
         }
     ]
+    show_metadata.pop("user_id", None)
     show_metadata.pop("user_name", None)
     show_metadata.pop("user_email", None)
     show_metadata["tags"] = [{"display_name": dis_name.strip()} for dis_name in show_metadata["taglist"].split(",")]
@@ -273,11 +274,12 @@ def archon_edit_show(id):
     # TODO see item.py same line
     show_metadata["users"] = [
         {
-            "id": show_metadata["users"],
+            "id": show_metadata["user_id"],
             "name": show_metadata["user_name"],
             "email": show_metadata["user_email"],
         }
     ]
+    show_metadata.pop("user_id", None)
     show_metadata.pop("user_name", None)
     show_metadata.pop("user_email", None)
 

--- a/arcsi/api/show.py
+++ b/arcsi/api/show.py
@@ -7,15 +7,16 @@ from flask_security import auth_token_required, roles_required, roles_accepted
 from marshmallow import fields, post_load, Schema
 from sqlalchemy import func
 
-from .utils import archive, get_shows_with_cover, save_file, slug, sort_for, normalise, comma_separated_params_to_list, filter_show_items
 from . import arcsi
+from .utils import archive, save_file, slug, sort_for, normalise, comma_separated_params_to_list
+from .utils import filter_show_items, get_shows, get_shows_with_cover
+from .item import item_archive_schema
 from arcsi.handler.upload import DoArchive
 from arcsi.model import db
 from arcsi.model.show import Show
 from arcsi.model.user import User
 from arcsi.model.tag import Tag
 from arcsi.model.utils import get_or_create
-from arcsi.api.item import item_archive_schema
 
 
 class ShowDetailsSchema(Schema):
@@ -102,7 +103,7 @@ def list_shows():
 
 
 @arcsi.route("/show/all_without_items", methods=["GET"])
-@auth_token_required
+@roles_accepted("admin", "host", "guest")
 def frontend_list_shows_without_items():
     return shows_schedule_schema.dump(get_shows_with_cover())
 
@@ -110,8 +111,7 @@ def frontend_list_shows_without_items():
 @arcsi.route("/archon/show/all", methods=["GET"])
 @roles_accepted("admin", "host")
 def archon_list_shows():
-    shows = Show.query.all()
-    return archon_shows_schema.dump(shows)   
+    return archon_shows_schema.dump(get_shows())   
 
 
 @arcsi.route("/show/schedule", methods=["GET"])
@@ -348,7 +348,7 @@ def archon_edit_show(id):
 
 
 @arcsi.route("/archon/show/<int:id>", methods=["GET"])
-@auth_token_required
+@roles_accepted("admin", "host", "guest")
 def archon_view_show(id):
     do = DoArchive()
     show_query = Show.query.filter_by(id=id)

--- a/arcsi/api/show.py
+++ b/arcsi/api/show.py
@@ -101,7 +101,7 @@ def list_shows():
 
 
 @arcsi.route("/show/all_without_items", methods=["GET"])
-@roles_accepted("admin", "host", "guest")
+@auth_token_required
 def frontend_list_shows_without_items():
     return shows_schedule_schema.dump(get_shows())
 
@@ -261,7 +261,7 @@ def archon_delete_show(id):
 
 
 @arcsi.route("/archon/show/<int:id>/edit", methods=["POST"])
-@roles_required("admin")
+@roles_accepted("admin", "host")
 def archon_edit_show(id):
     show_query = Show.query.filter_by(id=id)
     show = show_query.first_or_404()
@@ -347,7 +347,7 @@ def archon_edit_show(id):
 
 
 @arcsi.route("/archon/show/<int:id>", methods=["GET"])
-@roles_accepted("admin", "host", "guest")
+@auth_token_required
 def archon_view_show(id):
     do = DoArchive()
     show_query = Show.query.filter_by(id=id)

--- a/arcsi/api/user.py
+++ b/arcsi/api/user.py
@@ -1,4 +1,5 @@
 from flask import jsonify, make_response, request
+from flask_security import roles_required
 from flask_security.utils import verify_password
 from marshmallow import fields, post_load, Schema
 
@@ -35,12 +36,14 @@ headers = {"Content-Type": "application/json"}
 
 @arcsi.route("/users", methods=["GET"])
 @arcsi.route("/users/all", methods=["GET"])
+@roles_required("admin")
 def list_users():
     users = User.query.all()
     return many_user_details_schema.dumps(users)
 
 
 @arcsi.route("/user/<int:id>", methods=["GET"])
+@roles_required("admin")
 def view_user(id):
     user_query = User.query.filter_by(id=id)
     user = user_query.first_or_404()

--- a/arcsi/api/user.py
+++ b/arcsi/api/user.py
@@ -39,7 +39,7 @@ headers = {"Content-Type": "application/json"}
 @roles_required("admin")
 def list_users():
     users = User.query.all()
-    return many_user_details_schema.dumps(users)
+    return many_user_details_schema.dump(users)
 
 
 @arcsi.route("/user/<int:id>", methods=["GET"])

--- a/arcsi/api/utils.py
+++ b/arcsi/api/utils.py
@@ -159,6 +159,10 @@ def get_shows():
             )
     return shows
 
+def get_managed_shows(user):
+    shows = Show.query.filter(Show.users == user).all()
+    return shows
+
 def show_item_duplications_number(item):
     existing_items = Show.query.filter(Show.id == item.shows[0].id).first().items
     existing_items_with_same_name = existing_items.filter_by(name=item.name)

--- a/arcsi/api/utils.py
+++ b/arcsi/api/utils.py
@@ -149,15 +149,6 @@ def archive(archive_base, archive_file_name, archive_idx):
 
     return archive_url
 
-def get_items():
-    items = Item.query.all()
-    return items
-
-def get_managed_items(user):
-    managed_shows = Show.query.filter(Show.users.contains(user)).all()
-    managed_items = Item.query.filter(Item.shows.contains(managed_shows)).all()
-    return managed_items
-
 def get_shows():
     shows = Show.query.all()
     return shows
@@ -172,10 +163,25 @@ def get_shows_with_cover():
             )
     return shows
 
-
 def get_managed_shows(user):
     managed_shows = Show.query.filter(Show.users.contains(user)).all()
     return managed_shows
+
+def get_managed_show(user, id):
+    managed_show = Show.query.filter(Show.users.contains(user)).filter(Show.id == id).all()
+    return managed_show
+
+def get_items():
+    items = Item.query.all()
+    return items
+
+def get_managed_items(user):
+    managed_shows = get_managed_shows(user)
+    managed_items = []
+    for managed_show in managed_shows:
+        managed_items_for_current_show = Item.query.filter(Item.shows.contains(managed_show)).all()
+        managed_items.extend(managed_items_for_current_show)
+    return managed_items
 
 def show_item_duplications_number(item):
     existing_items = Show.query.filter(Show.id == item.shows[0].id).first().items

--- a/arcsi/api/utils.py
+++ b/arcsi/api/utils.py
@@ -149,7 +149,20 @@ def archive(archive_base, archive_file_name, archive_idx):
 
     return archive_url
 
+def get_items():
+    items = Item.query.all()
+    return items
+
+def get_managed_items(user):
+    managed_shows = Show.query.filter(Show.users.contains(user)).all()
+    managed_items = Item.query.filter(Item.shows.contains(managed_shows)).all()
+    return managed_items
+
 def get_shows():
+    shows = Show.query.all()
+    return shows
+
+def get_shows_with_cover():
     do = DoArchive()
     shows = Show.query.all()
     for show in shows:
@@ -159,9 +172,10 @@ def get_shows():
             )
     return shows
 
+
 def get_managed_shows(user):
-    shows = Show.query.filter(Show.users == user).all()
-    return shows
+    managed_shows = Show.query.filter(Show.users.contains(user)).all()
+    return managed_shows
 
 def show_item_duplications_number(item):
     existing_items = Show.query.filter(Show.id == item.shows[0].id).first().items

--- a/arcsi/model/role.py
+++ b/arcsi/model/role.py
@@ -7,8 +7,8 @@ class Role(db.Model, RoleMixin):
     """
     Proposed roles:
     * admin -- everything
-    * host -- manage show, manage items
-    * guest -- manage item(s)
+    * host -- can manage assigned shows and items
+    * guest -- have access for basic endpoints
     """
 
     __tablename__ = "roles"

--- a/arcsi/templates/base.html
+++ b/arcsi/templates/base.html
@@ -57,7 +57,7 @@
             <div class="has-submenu admin-menu" title="ADMIN INTERFACE">
               <i class="fas fa-users-cog"></i>
               <div class="hidden-sub">
-                <a href="{{ url_for('router.list_users') }}">All users</a>
+                <a href="{{ url_for('router.view_list_users') }}">All users</a>
               </div>
             </div>
             {% endif %}

--- a/arcsi/templates/base.html
+++ b/arcsi/templates/base.html
@@ -42,8 +42,10 @@
           
           <div class="adminmenu">
             <a href="/doc" title="API documentation"><i class="fa fa-book"></i></a>
-            {% if current_user.is_authenticated %}
+            {% if current_user.has_role("admin") %}
             <a href="{{ url_for('router.view_data') }}" title="Statistics"><i class="fa fa-database"></i></a>
+            {% endif %}
+            {% if current_user.is_authenticated %}
             <a href="{{ url_for('router.view_user') }}" title="Profile"><i class="far fa-user-circle"></i></a>
             <a href="{{ url_for('security.logout') }}" title="Logout"><i class="fas fa-sign-out-alt"></i></a>
             {% else %}

--- a/arcsi/templates/base.html
+++ b/arcsi/templates/base.html
@@ -28,9 +28,13 @@
       <div class="navigation-block">
         <nav>
           <ul>
+            {% if current_user.has_role("admin") %}
             <li><a href="{{ url_for('router.add_show') }}">Add new show</a></li>
+            {% endif %}
             <li><a href="{{ url_for('router.list_shows') }}">Shows archive</a></li>
+            {% if current_user.has_role("admin") or current_user.has_role("host") %}
             <li><a href="{{ url_for('router.add_item') }}">Add new item</a></li>
+            {% endif %}
             <li><a href="{{ url_for('router.list_items') }}">Items archive</a></li>
           </ul>
         </nav> 

--- a/arcsi/templates/item/add.html
+++ b/arcsi/templates/item/add.html
@@ -6,28 +6,29 @@
 
 {% block content %}
 <form action="{{ url_for('arcsi.archon_add_item') }}" method="post" enctype="multipart/form-data">
-<article class="add-infos">
 
-<div>
+<article class="add-infos">
+  <div>
     <label for="shows">Episode of show:</label>
     {% if current_user.has_role("admin") %}
     <input type="hidden" name="show_name" id="show_name" value="{{ shows[0].name }}">
     <select name="shows" id="shows"
-    onchange="this.previousElementSibling.value=this.options[this.selectedIndex].text">
-    <option value="">--Please choose an option--</option>
-    {% for show in shows %}
-    <option value="{{ show.id }}">{{ show.name }}</option>
-    {% endfor %}
+      onchange="this.previousElementSibling.value=this.options[this.selectedIndex].text">
+      <option value="">--Please choose an option--</option>
+      {% for show in shows %}
+      <option value="{{ show.id }}">{{ show.name }}</option>
+      {% endfor %}
     </select>
     {% else %}
-    <input type="hidden" name="show_name" id="show_name" value="{{ current_user.shows[0].name }}"><select name="shows" id="shows"
+    <input type="hidden" name="show_name" id="show_name" value="{{ current_user.shows[0].name }}">
+    <select name="shows" id="shows"
       onchange="this.previousElementSibling.value=this.options[this.selectedIndex].text">
       {% for show in current_user.shows %}
       <option value="{{ show.id }}">{{ show.name }}</option>
       {% endfor %}
     </select>
     {% endif %}
-</div>
+  </div>
 
   <div>
     <label for="number">Episode number</label>
@@ -49,14 +50,14 @@
     <input name="external_url" id="external_url">
   </div>
 
-<div>
+  <div>
     <label for="language">Episode language</label>
     <select name="language" id="language">
       <option id="music" value="music">Music</option>
       <option id="hu_hu" value="hu_hu" selected>Magyar</option>
       <option id="en_uk" value="en_uk">English</option>
     </select>
-</div>
+  </div>
 
   <div>
     <label for="taglist">Item tag list (separate with commas)</label>

--- a/arcsi/templates/item/add.html
+++ b/arcsi/templates/item/add.html
@@ -53,8 +53,8 @@
   <div>
     <label for="language">Episode language</label>
     <select name="language" id="language">
-      <option id="music" value="music">Music</option>
-      <option id="hu_hu" value="hu_hu" selected>Magyar</option>
+      <option id="music" value="music" selected>Music</option>
+      <option id="hu_hu" value="hu_hu">Magyar</option>
       <option id="en_uk" value="en_uk">English</option>
     </select>
   </div>
@@ -71,12 +71,12 @@
 
   <div>
     <label for="play_file">Play file</label>
-    <input type="file" name="play_file" id="play_file">
+    <input type="file" accept= ".mp3" name="play_file" id="play_file">
   </div>
 
   <div>
     <label for="image_file">Episode cover image</label>
-    <input type="file" name="image_file" id="image_file">
+    <input type="file" accept= "image/*" name="image_file" id="image_file">
   </div>
 
   <div>

--- a/arcsi/templates/item/add.html
+++ b/arcsi/templates/item/add.html
@@ -70,7 +70,7 @@
   </div>
 
   <div>
-    <label for="play_file">Play file</label>
+    <label for="play_file">Audio file</label>
     <input type="file" accept= ".mp3" name="play_file" id="play_file">
   </div>
 
@@ -88,7 +88,7 @@
       onclick="this.previousElementSibling.value=this.checked?1:0">
   </div>
 
-  <h4>WARNING, THESE OVERWRITE SHOW-LEVEL SETTINGS!</h4>
+  <!-- TODO WARNING, THESE OVERWRITE SHOW-LEVEL SETTINGS! revisit this message -->
 
   <div>
     <label for="archive_lahmastore">Archive to Lahmastore</label>
@@ -96,6 +96,9 @@
       onclick="this.previousElementSibling.value=this.checked?1:0" checked>
     <input type="hidden" name="uploader" id="uploader" value="{{ current_user.email }}">
   </div>
+
+  <p>For <b>Live</b> episodes please use an <b>image</b> between <b>200-500 kB</b></p>
+  <p>For <b>Broadcasted</b> episodes next to the <b>image</b> please upload the <b>audio</b> in <b>.mp3 format</b></p>
   
   <div>
     <input type="submit" value="Add">

--- a/arcsi/templates/item/add.html
+++ b/arcsi/templates/item/add.html
@@ -103,4 +103,8 @@
 
 </article>
 </form>
+
+{{ ckeditor.load(pkg_type="basic") }}
+{{ ckeditor.config(name="description") }}
+
 {% endblock %}

--- a/arcsi/templates/item/edit.html
+++ b/arcsi/templates/item/edit.html
@@ -71,7 +71,7 @@
   </div>
 
   <div>
-    <label for="play_file">Play file</label>
+    <label for="play_file">Audio file</label>
     <input type="file" accept= ".mp3" name="play_file" id="play_file" value="{{ item.play_file_name }}">
   </div>
 
@@ -86,7 +86,6 @@
       {% if item.live %} value="1" {% else %} value="0" {% endif %}>
     <input type="checkbox" onclick="this.previousElementSibling.value=this.checked?1:0"
       {% if item.live %} checked {% endif %}>
-    <p>TODO THIS DIFFERENTLY ON EDIT</p>
     <label for="broadcast">Broadcast</label>
     <input type="hidden" id="broadcast" name="broadcast"
       {% if item.broadcast %} value="1" {% else %} value="0" {% endif %}>
@@ -103,6 +102,9 @@
     <!-- TODO updated_at ? uploader means anything here? -->
     <input type="hidden" name="uploader" id="uploader" value="{{ current_user.email }}">
   </div>
+
+  <p>For <b>Live</b> episodes please use an <b>image</b> between <b>200-500 kB</b></p>
+  <p>For <b>Broadcasted</b> episodes next to the <b>image</b> please upload the <b>audio</b> in <b>.mp3 format</b></p>
 
   <div>
     <input type="submit" value="Update">

--- a/arcsi/templates/item/edit.html
+++ b/arcsi/templates/item/edit.html
@@ -9,97 +9,103 @@
 
 <article class="add-infos">
   <div>
-  <label for="shows">Episode of show:</label>
-  {% if current_user.has_role("admin") %}
-  <input type="hidden" name="show_name" id="show_name" value="{{ shows[0].name }}"><select name="shows" id="shows"
-  onchange="this.previousElementSibling.value=this.options[this.selectedIndex].text">
-  <option value="{{item.shows[0].id}}">{{ item.shows[0].name }}</option>
-  {% for show in shows %}
-  <option value="{{ show.id }}">{{ show.name }}</option>
-  {% endfor %}
-</select>
-  {% else %}
-  <input type="hidden" name="show_name" id="show_name" value="{{ item.shows[0].name }}"><select name="shows" id="shows"
-    onchange="this.previousElementSibling.value=this.options[this.selectedIndex].text">
-    {% for show in item.shows %}
-    <option value="{{ show.id }}">{{ show.name }}</option>
-    {% endfor %}
-  </select>
-  {% endif %}
-</div>
+    <label for="shows">Episode of show:</label>
+    {% if current_user.has_role("admin") %}
+    <input type="hidden" name="show_name" id="show_name" value="{{ shows[0].name }}">
+    <select name="shows" id="shows"
+      onchange="this.previousElementSibling.value=this.options[this.selectedIndex].text">
+      <option value="{{item.shows[0].id}}">{{ item.shows[0].name }}</option>
+      {% for show in shows %}
+      <option value="{{ show.id }}">{{ show.name }}</option>
+      {% endfor %}
+    </select>
+    {% else %}
+    <input type="hidden" name="show_name" id="show_name" value="{{ item.shows[0].name }}">
+    <select name="shows" id="shows"
+      onchange="this.previousElementSibling.value=this.options[this.selectedIndex].text">
+      {% for show in item.shows %}
+      <option value="{{ show.id }}">{{ show.name }}</option>
+      {% endfor %}
+    </select>
+    {% endif %}
+  </div>
 
-<div>
-  <label for="number">Episode number</label>
-  <input type="number" name="number" id="number" value="{{ item.number }}">
-</div>
+  <div>
+    <label for="number">Episode number</label>
+    <input type="number" name="number" id="number" value="{{ item.number }}">
+  </div>
 
-<div>
-  <label for="name">Episode name</label>
-  <input name="name" id="name" value="{{ item.name }}">
-</div>
+  <div>
+    <label for="name">Episode name</label>
+    <input name="name" id="name" value="{{ item.name }}">
+  </div>
 
-<div>
-  <label for="description">Episode description</label><br>
-  <textarea name="description" id="description" value="{{ item.description }}">{{ item.description }}</textarea>
-</div>
+  <div>
+    <label for="description">Episode description</label><br>
+    <textarea name="description" id="description" value="{{ item.description }}">{{ item.description }}</textarea>
+  </div>
 
-<div>
-  <label for="external_url">External link</label>
-  <input name="external_url" id="external_url" value="{{ item.external_url }}">
-</div>
+  <div>
+    <label for="external_url">External link</label>
+    <input name="external_url" id="external_url" value="{{ item.external_url }}">
+  </div>
 
-<div>
-  <label for="language">Episode language</label>
-  <select name="language" id="language">
-    <option id="music" value="music">Music</option>
-    <option id="hu_hu" value="hu_hu" selected>Magyar</option>
-    <option id="en_uk" value="en_uk">English</option>
-  </select>
-</div>
+  <div>
+    <label for="language">Episode language</label>
+    <select name="language" id="language">
+      <option id="music" value="music">Music</option>
+      <option id="hu_hu" value="hu_hu" selected>Magyar</option>
+      <option id="en_uk" value="en_uk">English</option>
+    </select>
+  </div>
 
   <div>
     <label for="taglist">Item tag list (separate with commas)</label>
     <input name="taglist" id="taglist" value="{% for tag in item.tags %}{{tag.display_name}},{% endfor %}">
   </div>
 
-<div>
-  <label for="play_date">Play date</label>
-  <input type="date" name="play_date" id="play_date" value="{{ item.play_date }}">
-</div>
+  <div>
+    <label for="play_date">Play date</label>
+    <input type="date" name="play_date" id="play_date" value="{{ item.play_date }}">
+  </div>
 
-<div>
-  <label for="play_file">Play file</label>
-  <input type="file" name="play_file" id="play_file" value="{{ item.play_file_name }}">
-</div>
+  <div>
+    <label for="play_file">Play file</label>
+    <input type="file" name="play_file" id="play_file" value="{{ item.play_file_name }}">
+  </div>
 
-<div>
-  <label for="image_file">Episode cover image</label>
-  <input type="file" name="image_file" id="image_file" value="{{ item.image_url }}">
-</div>
+  <div>
+    <label for="image_file">Episode cover image</label>
+    <input type="file" name="image_file" id="image_file" value="{{ item.image_url }}">
+  </div>
 
-<div>  
-  <label for="live">Live</label>
-  <input type="hidden" name="live" id="live" {% if item.live %} value="1" {% else %} value="0" {% endif %}><input
-    type="checkbox" onclick="this.previousElementSibling.value=this.checked?1:0" {% if item.live %} checked {% endif %}>
-  <p>TODO THIS DIFFERENTLY ON EDIT</p>
-  <label for="broadcast">Broadcast</label>
-  <input type="hidden" id="broadcast" name="broadcast" {% if item.broadcast %} value="1" {% else %} value="0"
-    {% endif %}><input type="checkbox" onclick="this.previousElementSibling.value=this.checked?1:0"
-    {% if item.broadcast %} checked {% endif %}>
+  <div>  
+    <label for="live">Live</label>
+    <input type="hidden" name="live" id="live" 
+      {% if item.live %} value="1" {% else %} value="0" {% endif %}>
+    <input type="checkbox" onclick="this.previousElementSibling.value=this.checked?1:0"
+      {% if item.live %} checked {% endif %}>
+    <p>TODO THIS DIFFERENTLY ON EDIT</p>
+    <label for="broadcast">Broadcast</label>
+    <input type="hidden" id="broadcast" name="broadcast"
+      {% if item.broadcast %} value="1" {% else %} value="0" {% endif %}>
+    <input type="checkbox" onclick="this.previousElementSibling.value=this.checked?1:0"
+      {% if item.broadcast %} checked {% endif %}>
   </div>
 
   <div>   
-  <label for="archive_lahmastore">Archive to Lahmastore</label>
-  <input type="hidden" id="archive_lahmastore" name="archive_lahmastore" {% if item.archive_lahmastore %} value="1"
-    {% else %} value="0" {% endif %}><input type="checkbox" onclick="this.previousElementSibling.value=this.checked?1:0"
-    {% if item.archive_lahmastore %} checked {% endif %}>
-  <!-- TODO updated_at ? uploader means anything here? -->
-  <input type="hidden" name="uploader" id="uploader" value="{{ current_user.email }}">
-</div>
+    <label for="archive_lahmastore">Archive to Lahmastore</label>
+    <input type="hidden" id="archive_lahmastore" name="archive_lahmastore"
+      {% if item.archive_lahmastore %} value="1" {% else %} value="0" {% endif %}>
+    <input type="checkbox" onclick="this.previousElementSibling.value=this.checked?1:0"
+      {% if item.archive_lahmastore %} checked {% endif %}>
+    <!-- TODO updated_at ? uploader means anything here? -->
+    <input type="hidden" name="uploader" id="uploader" value="{{ current_user.email }}">
+  </div>
 
-<div>
-  <input type="submit" value="Update">
-</div>  
+  <div>
+    <input type="submit" value="Update">
+  </div>  
 </article>
 </form>
 {% endblock %}

--- a/arcsi/templates/item/edit.html
+++ b/arcsi/templates/item/edit.html
@@ -53,9 +53,9 @@
   <div>
     <label for="language">Episode language</label>
     <select name="language" id="language">
-      <option id="music" value="music" {% if item.language="music" %} selected {% endif %}>Music</option>
-      <option id="hu_hu" value="hu_hu" {% if item.language="hu_hu" %} selected {% endif %}>Magyar</option>
-      <option id="en_uk" value="en_uk" {% if item.language="en_uk" %} selected {% endif %}>English</option>
+      <option id="music" value="music" {% if item.language=="music" %} selected {% endif %}>Music</option>
+      <option id="hu_hu" value="hu_hu" {% if item.language=="hu_hu" %} selected {% endif %}>Magyar</option>
+      <option id="en_uk" value="en_uk" {% if item.language=="en_uk" %} selected {% endif %}>English</option>
     </select>
   </div>
 

--- a/arcsi/templates/item/edit.html
+++ b/arcsi/templates/item/edit.html
@@ -108,4 +108,8 @@
   </div>  
 </article>
 </form>
+
+{{ ckeditor.load(pkg_type="basic") }}
+{{ ckeditor.config(name="description") }}
+
 {% endblock %}

--- a/arcsi/templates/item/edit.html
+++ b/arcsi/templates/item/edit.html
@@ -53,9 +53,9 @@
   <div>
     <label for="language">Episode language</label>
     <select name="language" id="language">
-      <option id="music" value="music">Music</option>
-      <option id="hu_hu" value="hu_hu" selected>Magyar</option>
-      <option id="en_uk" value="en_uk">English</option>
+      <option id="music" value="music" {% if item.language="music" %} selected {% endif %}>Music</option>
+      <option id="hu_hu" value="hu_hu" {% if item.language="hu_hu" %} selected {% endif %}>Magyar</option>
+      <option id="en_uk" value="en_uk" {% if item.language="en_uk" %} selected {% endif %}>English</option>
     </select>
   </div>
 
@@ -71,12 +71,12 @@
 
   <div>
     <label for="play_file">Play file</label>
-    <input type="file" name="play_file" id="play_file" value="{{ item.play_file_name }}">
+    <input type="file" accept= ".mp3" name="play_file" id="play_file" value="{{ item.play_file_name }}">
   </div>
 
   <div>
     <label for="image_file">Episode cover image</label>
-    <input type="file" name="image_file" id="image_file" value="{{ item.image_url }}">
+    <input type="file" accept= "image/*" name="image_file" id="image_file" value="{{ item.image_url }}">
   </div>
 
   <div>  

--- a/arcsi/templates/item/list.html
+++ b/arcsi/templates/item/list.html
@@ -24,7 +24,6 @@
         <p>Episode play date: {{item["play_date"]}}</p>
         <p>Episode play file name: {{item["play_file_name"]}}</p>
         <p>Episode archived?: {{item["archived"]}}</p>
-        <p>permalink <a href="{{ url_for('router.view_item', id=item['id']) }}"><b>{{item['id']}}</b></a></p>
     </div>
     {% endfor %}    
 </div> 

--- a/arcsi/templates/item/view.html
+++ b/arcsi/templates/item/view.html
@@ -41,7 +41,7 @@
 </ul>
 <hr>
 {% if current_user.has_role("admin") or current_user.has_role("host") %}
-<p><a href="{{ url_for('router.edit_item', id=item['id']) }}">Edit Episode</a> || <a
-        href="{{ url_for('arcsi.archon_delete_item', id=item['id']) }}">Delete Episode</a></p>
+<p><a href="{{ url_for('router.edit_item', id=item['id']) }}">Edit Episode</a> {% if current_user.has_role("admin") %}|| <a
+        href="{{ url_for('arcsi.archon_delete_item', id=item['id']) }}">Delete Episode</a>{% endif %}</p>
 {% endif %}
 {% endblock %}

--- a/arcsi/templates/item/view.html
+++ b/arcsi/templates/item/view.html
@@ -40,6 +40,8 @@
   {% endfor %}
 </ul>
 <hr>
+{% if current_user.has_role("admin") or current_user.has_role("host") %}
 <p><a href="{{ url_for('router.edit_item', id=item['id']) }}">Edit Episode</a> || <a
         href="{{ url_for('arcsi.archon_delete_item', id=item['id']) }}">Delete Episode</a></p>
+{% endif %}
 {% endblock %}

--- a/arcsi/templates/show/add.html
+++ b/arcsi/templates/show/add.html
@@ -101,4 +101,8 @@
 
 </article>
 </form>
+
+{{ ckeditor.load(pkg_type="basic") }}
+{{ ckeditor.config(name="description") }}
+
 {% endblock %}

--- a/arcsi/templates/show/add.html
+++ b/arcsi/templates/show/add.html
@@ -8,15 +8,9 @@
 <form action="{{ url_for('arcsi.archon_add_show') }}" method="post" enctype="multipart/form-data">
 <article class="add-infos">
 
-  <div>
-    <label for="users">Host:</label>
-    <input type="hidden" name="user_name" id="user_name" value="{{ current_user.name }}">
-    <input type="hidden" name="user_email" id="user_email" value="{{ current_user.email }}">
-    <select name="users" id="users">
-      <option value="{{current_user.id}}"> {% if current_user.name %} {{ current_user.name }} {% else %}
-        {{ current_user.email }} {% endif %}</option>
-    </select>
-  </div>
+  <input type="hidden" name="user_id" id="user_id" value="{{ current_user.id }}">
+  <input type="hidden" name="user_name" id="user_name" value="{{ current_user.name }}">
+  <input type="hidden" name="user_email" id="user_email" value="{{ current_user.email }}">
 
   <div>
     <label for="active">Active</label>

--- a/arcsi/templates/show/add.html
+++ b/arcsi/templates/show/add.html
@@ -42,8 +42,8 @@
   <div>
       <label for="language">Show language</label>
       <select name="language" id="language">
-        <option id="music" value="music">Music</option>
-        <option id="hu_hu" value="hu_hu" selected>Magyar</option>
+        <option id="music" value="music" selected>Music</option>
+        <option id="hu_hu" value="hu_hu">Magyar</option>
         <option id="en_uk" value="en_uk">English</option>
       </select>
   </div>
@@ -60,7 +60,7 @@
 
   <div>
     <label for="image_file">Cover image</label>
-    <input type="file" name="image_file" id="image_file">
+    <input type="file" accept= "image/*" name="image_file" id="image_file">
   </div>
 
   <div>

--- a/arcsi/templates/show/edit.html
+++ b/arcsi/templates/show/edit.html
@@ -42,11 +42,10 @@
 
   <div>
     <label for="language">Show language</label>
-    <!-- TODO dynamic checked here based on db record -->
     <select name="language" id="language">
-      <option id="music" value="music">Music</option>
-      <option id="hu_hu" value="hu_hu" selected>Magyar</option>
-      <option id="en_uk" value="en_uk">English</option>
+      <option id="music" value="music" {% if show.language="music" %} selected {% endif %}>Music</option>
+      <option id="hu_hu" value="hu_hu" {% if show.language="hu_hu" %} selected {% endif %}>Magyar</option>
+      <option id="en_uk" value="en_uk" {% if show.language="en_uk" %} selected {% endif %}>English</option>
     </select>
   </div>
 
@@ -62,7 +61,7 @@
 
   <div>
     <label for="image_file">Cover image</label>
-    <input type="file" name="image_file" id="image_file">
+    <input type="file" accept= "image/*" name="image_file" id="image_file">
   </div>
 
   <div>

--- a/arcsi/templates/show/edit.html
+++ b/arcsi/templates/show/edit.html
@@ -8,15 +8,9 @@
 <form action="{{ url_for('arcsi.archon_edit_show', id=show.id) }}" method="post" enctype="multipart/form-data">
 <article class="add-infos">
 
-  <div>
-    <label for="users">Host: </label>
-    <input type="hidden" name="user_name" id="user_name" value="{{ current_user.name }}">
-    <input type="hidden" name="user_email" id="user_email" value="{{ current_user.email }}">
-    <select name="users" id="users">
-      <option value="{{current_user.id}}"> {% if current_user.name %} {{ current_user.name }} {% else %}
-        {{ current_user.email }} {% endif %}</option>
-    </select>
-  </div>
+  <input type="hidden" name="user_id" id="user_id" value="{{ current_user.id }}">
+  <input type="hidden" name="user_name" id="user_name" value="{{ current_user.name }}">
+  <input type="hidden" name="user_email" id="user_email" value="{{ current_user.email }}">
 
   <div>
     <label for="active">Active</label>

--- a/arcsi/templates/show/edit.html
+++ b/arcsi/templates/show/edit.html
@@ -43,9 +43,9 @@
   <div>
     <label for="language">Show language</label>
     <select name="language" id="language">
-      <option id="music" value="music" {% if show.language="music" %} selected {% endif %}>Music</option>
-      <option id="hu_hu" value="hu_hu" {% if show.language="hu_hu" %} selected {% endif %}>Magyar</option>
-      <option id="en_uk" value="en_uk" {% if show.language="en_uk" %} selected {% endif %}>English</option>
+      <option id="music" value="music" {% if show.language=="music" %} selected {% endif %}>Music</option>
+      <option id="hu_hu" value="hu_hu" {% if show.language=="hu_hu" %} selected {% endif %}>Magyar</option>
+      <option id="en_uk" value="en_uk" {% if show.language=="en_uk" %} selected {% endif %}>English</option>
     </select>
   </div>
 

--- a/arcsi/templates/show/edit.html
+++ b/arcsi/templates/show/edit.html
@@ -84,15 +84,14 @@
     <input type="time" name="end" id="end" value="{{ show.end }}">
   </div>
 
-
-  <h4>TODO THIS DIFFERENTLY ON EDIT</h4>
-
   <div>
     <label for="archive_lahmastore">Archive to Lahmastore</label>
     <input type="hidden" id="archive_lahmastore" name="archive_lahmastore" {% if show.archive_lahmastore %} value="1"
       {% else %} value="0" {% endif %}><input type="checkbox" onclick="this.previousElementSibling.value=this.checked?1:0"
       {% if show.archive_lahmastore %} checked {% endif %}>
   </div>
+
+  <p>Please use an <b>image</b> between <b>200-500 kB</b> as your show's cover</p>
 
   <div>
     <input type="submit" value="Update">

--- a/arcsi/templates/show/edit.html
+++ b/arcsi/templates/show/edit.html
@@ -106,4 +106,8 @@
 
 </article>
 </form>
+
+{{ ckeditor.load(pkg_type="basic") }}
+{{ ckeditor.config(name="description") }}
+
 {% endblock %}

--- a/arcsi/templates/show/view.html
+++ b/arcsi/templates/show/view.html
@@ -48,8 +48,9 @@
     </li>
     {% endfor %}
 </ul>
- <hr> 
-<p><a href="{{ url_for('router.edit_show', id=show['id']) }}">Edit show</a> || <a
-        href="{{ url_for('arcsi.archon_delete_show', id=show['id']) }}">Delete show</a>
-    
+<hr>
+{% if current_user.has_role("admin") or current_user.has_role("host") %}
+<p><a href="{{ url_for('router.edit_show', id=show['id']) }}">Edit show</a>{% if current_user.has_role("admin")%} || <a
+        href="{{ url_for('arcsi.archon_delete_show', id=show['id']) }}">Delete show</a>{% endif %}
+{% endif %}
 {% endblock %}

--- a/arcsi/templates/user/view.html
+++ b/arcsi/templates/user/view.html
@@ -12,9 +12,9 @@
 <p>User butt password: {{user.butt_pw}}</p>
 <p>User hosted shows: {% for show in user.shows %} {{ show.name }} {% endfor %}</p>
 <p>User API token: {{user.get_auth_token()}}</p>
-<a href="{{ url_for('router.edit_user', id=user['id']) }}">Edit user</a>
 {% if user.has_role("admin") %}
-
+<!-- TODO implement user edit -->
+<a href="{{ url_for('router.edit_user', id=user['id']) }}">Edit user</a>
 <h4>ADMIN EYES</h4>
 <p>User roles: {% for role in user.roles %} {{ role.name }} {% endfor %}</p>
 {% endif %}

--- a/arcsi/view/item.py
+++ b/arcsi/view/item.py
@@ -3,7 +3,8 @@ from flask_login import current_user
 from flask_security import login_required, roles_accepted
 
 
-from arcsi.api import archon_view_item, listen_play_file, archon_list_items, frontend_list_shows_without_items
+from arcsi.api import archon_view_item, listen_play_file, archon_list_items, shows_minimal_schema
+from arcsi.api.utils import get_shows, get_managed_shows
 from arcsi.view import router
 
 
@@ -17,14 +18,15 @@ def list_items():
 @router.route("/item/add", methods=["GET"])
 @roles_accepted("admin", "host")
 def add_item():
-    shows = {}
-
     if not current_user.has_role("admin") and not current_user.shows.all():
         # TODO error handling
         return "add new show first"
 
+    shows = {}
     if current_user.has_role("admin"):
-        shows = frontend_list_shows_without_items()
+        shows = shows_minimal_schema.dump(get_shows())
+    if current_user.has_role("host"):
+        shows = shows_minimal_schema.dump(get_managed_shows(current_user))
 
     shows_sorted = sorted(shows, key=lambda k: k['name'])
     return render_template("item/add.html", shows=shows_sorted)
@@ -52,6 +54,12 @@ def edit_item(id):
     item = archon_view_item(id)
     if (hasattr(item, 'status_code') and item.status_code == 404):
         return "Episode not found"
-    shows = frontend_list_shows_without_items()
+    
+    shows = {}
+    if current_user.has_role("admin"):
+        shows = shows_minimal_schema.dump(get_shows())
+    if current_user.has_role("host"):
+        shows = shows_minimal_schema.dump(get_managed_shows(current_user))
+
     shows_sorted = sorted(shows, key=lambda k: k['name'])
     return render_template("item/edit.html", item=item, shows=shows_sorted)

--- a/arcsi/view/item.py
+++ b/arcsi/view/item.py
@@ -3,15 +3,19 @@ from flask_login import current_user
 from flask_security import login_required, roles_accepted
 
 
-from arcsi.api import archon_view_item, listen_play_file, archon_list_items, shows_minimal_schema
-from arcsi.api.utils import get_shows, get_managed_shows
+from arcsi.api import archon_view_item, listen_play_file, archon_items_schema, shows_minimal_schema
+from arcsi.api.utils import get_items, get_managed_items, get_shows, get_managed_shows
 from arcsi.view import router
 
 
 @router.route("/item/all")
 @login_required
 def list_items():
-    items = archon_list_items()
+    items = {}
+    if current_user.has_role("admin"):
+        items = archon_items_schema.dump(get_items())
+    if current_user.has_role("host"):
+        items = archon_items_schema.dump(get_managed_items(current_user))
     return render_template("item/list.html", items=items)
 
 

--- a/arcsi/view/show.py
+++ b/arcsi/view/show.py
@@ -1,5 +1,5 @@
 from flask import render_template
-from flask_security import login_required, roles_accepted
+from flask_security import login_required, roles_accepted, roles_required
 
 from arcsi.api import archon_list_shows, archon_view_show
 from arcsi.view import router
@@ -13,7 +13,7 @@ def list_shows():
 
 
 @router.route("/show/add", methods=["GET"])
-@roles_accepted("admin", "host")
+@roles_required("admin")
 def add_show():
     return render_template("show/add.html")
 

--- a/arcsi/view/show.py
+++ b/arcsi/view/show.py
@@ -1,4 +1,5 @@
 from flask import render_template
+from flask_login import current_user
 from flask_security import login_required, roles_accepted, roles_required
 
 from arcsi.api import archon_list_shows, archon_view_show
@@ -33,4 +34,6 @@ def edit_show(id):
     show = archon_view_show(id)
     if (hasattr(show, 'status_code') and show.status_code == 404):
         return "Show not found"
+    if (not current_user.has_role("admin") and not next(filter(lambda show: show['id']==id, current_user.shows))):
+        return "You don't have access to edit this show!"
     return render_template("show/edit.html", show=show)

--- a/arcsi/view/show.py
+++ b/arcsi/view/show.py
@@ -2,14 +2,19 @@ from flask import render_template
 from flask_login import current_user
 from flask_security import login_required, roles_accepted, roles_required
 
-from arcsi.api import archon_list_shows, archon_view_show
+from arcsi.api import archon_view_show, archon_shows_schema
+from arcsi.api.utils import get_shows, get_managed_shows
 from arcsi.view import router
 
 
 @router.route("/show/all")
 @login_required
 def list_shows():
-    shows = archon_list_shows()
+    shows = {}
+    if current_user.has_role("admin"):
+        shows = archon_shows_schema.dump(get_shows())
+    if current_user.has_role("host"):
+        shows = archon_shows_schema.dump(get_managed_shows(current_user))
     return render_template("show/list.html", shows=shows)
 
 

--- a/arcsi/view/show.py
+++ b/arcsi/view/show.py
@@ -3,7 +3,7 @@ from flask_login import current_user
 from flask_security import login_required, roles_accepted, roles_required
 
 from arcsi.api import archon_view_show, archon_shows_schema
-from arcsi.api.utils import get_shows, get_managed_shows
+from arcsi.api.utils import get_shows, get_managed_shows, get_managed_show
 from arcsi.view import router
 
 
@@ -39,6 +39,6 @@ def edit_show(id):
     show = archon_view_show(id)
     if (hasattr(show, 'status_code') and show.status_code == 404):
         return "Show not found"
-    if (not current_user.has_role("admin") and not next(filter(lambda show: show['id']==id, current_user.shows))):
+    if (not current_user.has_role("admin") and not get_managed_show(current_user, id)):
         return "You don't have access to edit this show!"
     return render_template("show/edit.html", show=show)

--- a/arcsi/view/user.py
+++ b/arcsi/view/user.py
@@ -8,8 +8,8 @@ from arcsi.view import router
 
 @router.route("/user/all")
 @roles_required('admin')
-def list_users():
-    users = list_users().json()
+def view_list_users():
+    users = list_users()
     return render_template("user/list.html", users=users)
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
     links:
       - "db"
     build: .
-    image: arcsi:0.4.3
+    image: arcsi:0.4.4
     restart: always
     expose:
       - 5666

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,6 +20,7 @@ email-validator==1.1.1
 filelock==3.0.12
 Flask==2.2.5
 Flask-BabelEx==0.9.4
+Flask-CKEditor==1.0.0
 Flask-Login==0.6.2
 Flask-Mail==0.9.1
 flask-marshmallow==0.12.0

--- a/test/postman/functional_test.postman_collection.json
+++ b/test/postman/functional_test.postman_collection.json
@@ -314,7 +314,8 @@
 							"    pm.response.to.have.status(403);\r",
 							"});"
 						],
-						"type": "text/javascript"
+						"type": "text/javascript",
+						"packages": {}
 					}
 				}
 			],
@@ -331,7 +332,7 @@
 					"mode": "formdata",
 					"formdata": [
 						{
-							"key": "users",
+							"key": "user_id",
 							"value": "1",
 							"type": "text"
 						},
@@ -492,7 +493,8 @@
 							"    pm.expect(show.id).to.be.an(\"number\")\r",
 							"})"
 						],
-						"type": "text/javascript"
+						"type": "text/javascript",
+						"packages": {}
 					}
 				}
 			],
@@ -509,7 +511,7 @@
 					"mode": "formdata",
 					"formdata": [
 						{
-							"key": "users",
+							"key": "user_id",
 							"value": "1",
 							"type": "text"
 						},
@@ -669,7 +671,8 @@
 							"    pm.expect(show.id).to.be.an(\"number\")\r",
 							"})"
 						],
-						"type": "text/javascript"
+						"type": "text/javascript",
+						"packages": {}
 					}
 				}
 			],
@@ -686,7 +689,7 @@
 					"mode": "formdata",
 					"formdata": [
 						{
-							"key": "users",
+							"key": "user_id",
 							"value": "1",
 							"type": "text"
 						},


### PR DESCRIPTION
- Cleaned up authentication annotations
- Separated Admin and Host use cases for Show and Item handling
  - Admins have access for each Show and Item by default
  - Hosts have access for managed Shows and the connecting Episodes/Items
- Removed not yet implemented features such as User edit and Show/Item delete from the views
- Added CKEdit for basic formatting features on descriptions
- Extended error messages, in case of Episode upload failures, now they are returned in the error response and logged as well
- Removed unnecessary User field from Show add and edit form, now it uses current_user by default
- Adjusted CI tests for the User field related change
- Item and Show edit form uses the stored language by default
- Fixed a bug on Admin's all Users view
- Uplifts for GitHub Actions 