### PR TITLE
Update uploader handle on forms

### DIFF
--- a/arcsi/templates/item/add.html
+++ b/arcsi/templates/item/add.html
@@ -94,7 +94,7 @@
     <label for="archive_lahmastore">Archive to Lahmastore</label>
     <input type="hidden" id="archive_lahmastore" name="archive_lahmastore" value="1"><input type="checkbox"
       onclick="this.previousElementSibling.value=this.checked?1:0" checked>
-    <input type="hidden" name="uploader" id="uploader" value="{{ current_user.email }}">
+    <input type="hidden" name="uploader" id="uploader" value="{{ current_user.name }}">
   </div>
 
   <p>For <b>Live</b> episodes please use an <b>image</b> between <b>200-500 kB</b></p>

--- a/arcsi/templates/item/edit.html
+++ b/arcsi/templates/item/edit.html
@@ -100,7 +100,7 @@
     <input type="checkbox" onclick="this.previousElementSibling.value=this.checked?1:0"
       {% if item.archive_lahmastore %} checked {% endif %}>
     <!-- TODO updated_at ? uploader means anything here? -->
-    <input type="hidden" name="uploader" id="uploader" value="{{ current_user.email }}">
+    <input type="hidden" name="uploader" id="uploader" value="{{ current_user.name }}">
   </div>
 
   <p>For <b>Live</b> episodes please use an <b>image</b> between <b>200-500 kB</b></p>


### PR DESCRIPTION
I didn't find any part in the views where the email value is used. 

It not quite private and useful to display uploader addresses.

This change puts user name there 

_**Note**_ When releasing this fix we should update current values for prod uploads