### PR TITLE
Features: reset and change pw 

### DIFF
--- a/arcsi/templates/security/change_password.html
+++ b/arcsi/templates/security/change_password.html
@@ -1,4 +1,4 @@
-{% extends "security/base.html" %}
+{% extends "base.html" %}
 {% from "security/_macros.html" import render_field_with_errors, render_field %}
 
 {% block content %}

--- a/arcsi/templates/security/forgot_password.html
+++ b/arcsi/templates/security/forgot_password.html
@@ -1,4 +1,4 @@
-{% extends "security/base.html" %}
+{% extends "base.html" %}
 {% from "security/_macros.html" import render_field_with_errors, render_field %}
 
 {% block content %}
@@ -9,5 +9,4 @@
     {{ render_field_with_errors(forgot_password_form.email) }}
     {{ render_field(forgot_password_form.submit) }}
 </form>
-{% include "security/_menu.html" %}
 {% endblock %}

--- a/arcsi/templates/security/login_user.html
+++ b/arcsi/templates/security/login_user.html
@@ -9,6 +9,7 @@
     {{ render_field_with_errors(login_user_form.email) }}
     {{ render_field_with_errors(login_user_form.password) }}
     {{ render_field_with_errors(login_user_form.remember) }}
+    <a href="{{ url_for('security.forgot_password') }}"><p>Reset password</p></a>
     {{ render_field(login_user_form.submit) }}
 </form>
 {% endblock %}

--- a/arcsi/templates/security/reset_password.html
+++ b/arcsi/templates/security/reset_password.html
@@ -1,4 +1,4 @@
-{% extends "security/base.html" %}
+{% extends "base.html" %}
 {% from "security/_macros.html" import render_field_with_errors, render_field %}
 
 {% block content %}
@@ -11,5 +11,4 @@
     {{ render_field_with_errors(reset_password_form.password_confirm) }}
     {{ render_field(reset_password_form.submit) }}
 </form>
-{% include "security/_menu.html" %}
 {% endblock %}

--- a/arcsi/templates/user/edit.html
+++ b/arcsi/templates/user/edit.html
@@ -6,25 +6,41 @@
 
 {% block content %}
 <form action="{{ url_for('arcsi.view_user', id=user.id) }}" method="post" enctype="multipart/form-data">
+  <div>
   <label for="name">Username</label>
   <input name="name" id="name" value="{{ user.name }}">
-  <p>TODO Use security templates/validation</p>
+  </div>
+  <div>
   <label for="email">User email</label>
   <input name="email" id="email" value="{{ user.email }}">
+  </div>
+  <div>
   <label for="password">User password</label>
-  <input name="password" id="password">
+  <a href="{{ url_for('security.change_password') }}"><p>Change password</p></a>
+  </div>
+  <div>
   <label for="butt_user">User butt username</label>
   <input name="butt_user" id="butt_user" value="{{ user.butt_user }}">
+  </div>
+  <div>
   <label for="butt_pw">User butt password</label>
   <input name="butt_pw" id="butt_pw" value="{{ user.butt_pw }}">
+  </div>
+  <div>
   <label for="active">User active</label>
   <input type="checkbox" name="active" id="active" {% if user.active%} checked {% endif %}>
+  </div>
+  <div>
   <label for="shows">User's shows:</label>
   <select name="shows" id="shows">
     {% for show in user.shows %}
     <option value="{{ show.id }}">{{show.name}}</option>
     {% endfor %}
   </select>
-  <input type="submit" value="Update">
+  </div>
+  <div>
+  <p> User editing features are under construction, to change password follow the link above </p>
+  <input type="submit" value="Update" disabled>
+  </div>
 </form>
 {% endblock %}

--- a/config.template.py
+++ b/config.template.py
@@ -15,7 +15,9 @@ SQLALCHEMY_TRACK_MODIFICATIONS = (
 # AUTHENTICATION
 # This enables Flask-Security to handle /register /login etc. so all-in-all: authentication
 # https://pythonhosted.org/Flask-Security/configuration.html
+SECURITY_CHANGEABLE = True
 SECURITY_SEND_REGISTER_EMAIL = True
+SECURITY_RECOVERABLE = True
 SECURITY_REGISTERABLE = True
 SECURITY_PASSWORD_SALT = "some_salt"
 SECURITY_USE_VERIFY_PASSWORD_CACHE = True


### PR DESCRIPTION
 - enabled in config --> added the fields to config.template
 - added base.html as base for reset, forgot, change templates
 - added links to login and edit-user templates


**Warning!**
These functionalities depend on `mail` for flask enabled and working in the target environment. (That's why I skipped config_ci and also why I can only half-test it.)
![Screenshot_2025-04-20_00-50-36](https://github.com/user-attachments/assets/c2facbe9-3387-4dd3-914c-80132f221858)
![Screenshot_2025-04-20_00-46-30](https://github.com/user-attachments/assets/3a286603-d9f4-4b2e-9973-d69872ebc52f)
