### PR TITLE
Switch from 3.8 buster python image to bullseye

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8-slim-buster
+FROM python:3.8-slim-bullseye
 
 ENV PYTHONDONTWRITEBYTECODE 1
 ENV PYTHONUNBUFFERED 1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
     links:
       - "db"
     build: .
-    image: arcsi:0.4.4
+    image: arcsi:0.4.5
     restart: always
     expose:
       - 5666


### PR DESCRIPTION
The buster 3.8 python image what we used is no longer supported, we changed it to the bullseye edition, as suggested in this [thread](https://stackoverflow.com/questions/76955036/build-started-failing-using-python3-8-docker-image-on-apt-get-update-and-instal) 